### PR TITLE
Added sample() methods and tests to all LogPrior classes

### DIFF
--- a/pints/_log_pdfs.py
+++ b/pints/_log_pdfs.py
@@ -37,18 +37,22 @@ class LogPrior(LogPDF):
     Represents the natural logarithm ``log(f(theta))`` of a known probability
     density function ``f(theta)``.
 
-    Priors are normalised: The integral ``f(theta)`` over all points ``theta``
-    in parameter space sums to 1.
+    Priors are *usually* normalised (i.e. the integral ``f(theta)`` over all
+    points ``theta`` in parameter space sums to 1), but this is not a strict
+    requirement.
     """
     def sample(self, n=1):
         """
         Returns ``n`` random samples from the underlying prior distribution.
+
+        The returned value is a numpy array with shape ``(n, d)`` where ``n``
+        is the requested number of samples, and ``d`` is the dimension of the
+        prior.
+
+        Note: This method is optional, in the sense that only a subsets of
+        inference methods require it.
         """
         raise NotImplementedError
-        #TODO Decide if `n` is needed
-        #TODO For n=1, decide whether to return (n, dim) array or (dim, ) array
-        #TODO Make this clear in the docstring!
-        #TODO Add test to ensure this is present for all priors.
 
 
 class LogLikelihood(LogPDF):

--- a/pints/_log_priors.py
+++ b/pints/_log_priors.py
@@ -72,7 +72,7 @@ class MultivariateNormalLogPrior(pints.LogPrior):
 
     For example::
 
-        p = MultivariateNormalPrior(
+        p = MultivariateNormalLogPrior(
                 np.array([0, 0]), np.array([[1, 0],[0, 1]]))
 
     """
@@ -114,7 +114,7 @@ class NormalLogPrior(pints.LogPrior):
 
     Defines a 1-d normal (log) prior with a given `mean` and `variance`.
 
-    For example: ``p = NormalPrior(0, 1)`` for a mean of ``0`` and variance
+    For example: ``p = NormalLogPrior(0, 1)`` for a mean of ``0`` and variance
     of ``1``.
     """
     def __init__(self, mean, variance):
@@ -147,15 +147,16 @@ class UniformLogPrior(pints.LogPrior):
     The range includes the lower, but not the upper boundaries, so that any
     point ``x`` with a non-zero prior must have ``lower <= x < upper``.
 
-    For example: ``p = UniformPrior([1,1,1], [10, 10, 100])``, or
-    ``p = UniformPrior(Boundaries([1,1,1], [10, 10, 100]))``.
+    For example: ``p = UniformLogPrior([1, 1, 1], [10, 10, 100])``, or
+    ``p = UniformLogPrior(Boundaries([1, 1, 1], [10, 10, 100]))``.
+
     """
     def __init__(self, lower_or_boundaries, upper=None):
         # Parse input arguments
         if upper is None:
             if not isinstance(lower_or_boundaries, pints.Boundaries):
                 raise ValueError(
-                    'UniformPrior requires a lower and an upper bound, or a'
+                    'UniformLogPrior requires a lower and an upper bound, or a'
                     ' single Boundaries object.')
             self._boundaries = lower_or_boundaries
         else:

--- a/pints/_log_priors.py
+++ b/pints/_log_priors.py
@@ -67,8 +67,8 @@ class MultivariateNormalLogPrior(pints.LogPrior):
     """
     *Extends:* :class:`LogPrior`
 
-    Defines a multivariate normal (log)prior with a given `mean` and
-    `covariance` matrix.
+    Defines a multivariate normal (log)prior with a given ``mean`` and
+    ``covariance`` matrix.
 
     For example::
 
@@ -112,15 +112,16 @@ class NormalLogPrior(pints.LogPrior):
     """
     *Extends:* :class:`LogPrior`
 
-    Defines a 1-d normal (log) prior with a given `mean` and `variance`.
+    Defines a 1-d normal (log) prior with a given ``mean`` and
+    ``standard_deviation``.
 
-    For example: ``p = NormalLogPrior(0, 1)`` for a mean of ``0`` and variance
-    of ``1``.
+    For example: ``p = NormalLogPrior(0, 1)`` for a mean of ``0`` and standard
+    deviation of ``1``.
     """
-    def __init__(self, mean, variance):
+    def __init__(self, mean, standard_deviation):
         # Parse input arguments
         self._mean = float(mean)
-        self._sigma = float(variance)
+        self._sigma = float(standard_deviation)
 
         # Cache constants
         self._offset = 1 / np.sqrt(2 * np.pi * self._sigma ** 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cma>=2
 matplotlib>=1.5
 numpy>=1.8
-scipy>=0.13
+scipy>=0.14

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'cma>=2',
         'numpy>=1.8',
-        'scipy>=0.13',
+        'scipy>=0.14',
         # Note: Matplotlib is loaded for debug plots, but to ensure pints runs
         # on systems without an attached display, it should never be imported
         # outside of plot() methods.

--- a/test/test_log_priors.py
+++ b/test/test_log_priors.py
@@ -122,6 +122,7 @@ class TestPrior(unittest.TestCase):
         lower = np.array([1, 2])
         upper = np.array([10, 20])
 
+        # Test normal construction
         p = pints.UniformLogPrior(lower, upper)
         m = float('-inf')
         self.assertEqual(p([0, 0]), m)
@@ -143,6 +144,33 @@ class TestPrior(unittest.TestCase):
         self.assertEqual(p([1, 20 - 1e-14]), w)
         self.assertEqual(p([5, 5]), w)
         self.assertEqual(p([5, 20 - 1e-14]), w)
+
+        # Test from boundaries object
+        b = pints.Boundaries(lower, upper)
+        p = pints.UniformLogPrior(b)
+        m = float('-inf')
+        self.assertEqual(p([0, 0]), m)
+        self.assertEqual(p([0, 5]), m)
+        self.assertEqual(p([0, 19]), m)
+        self.assertEqual(p([0, 21]), m)
+        self.assertEqual(p([5, 0]), m)
+        self.assertEqual(p([5, 21]), m)
+        self.assertEqual(p([15, 0]), m)
+        self.assertEqual(p([15, 5]), m)
+        self.assertEqual(p([15, 19]), m)
+        self.assertEqual(p([15, 21]), m)
+        self.assertEqual(p([10, 10]), m)
+        self.assertEqual(p([5, 20]), m)
+
+        w = -np.log(np.product(upper - lower))
+        self.assertEqual(p([1, 2]), w)
+        self.assertEqual(p([1, 5]), w)
+        self.assertEqual(p([1, 20 - 1e-14]), w)
+        self.assertEqual(p([5, 5]), w)
+        self.assertEqual(p([5, 20 - 1e-14]), w)
+
+        # Test bad constructor
+        self.assertRaises(ValueError, pints.UniformLogPrior, lower)
 
     def test_uniform_prior_sampling(self):
         lower = np.array([1, 2])

--- a/test/test_log_priors.py
+++ b/test/test_log_priors.py
@@ -17,11 +17,11 @@ class TestPrior(unittest.TestCase):
 
     def test_normal_prior(self):
         mean = 10
-        cov = 2
-        p = pints.NormalLogPrior(mean, cov)
+        std = 2
+        p = pints.NormalLogPrior(mean, std)
 
         n = 10000
-        r = 6 * np.sqrt(cov)
+        r = 6 * np.sqrt(std)
 
         # Test left half of distribution
         x = np.linspace(mean - r, mean, n)
@@ -29,11 +29,15 @@ class TestPrior(unittest.TestCase):
         self.assertTrue(np.all(px[1:] >= px[:-1]))
 
         # Test right half of distribution
-        y = np.linspace(mean, mean + r, n)
+        y = np.linspace(mean, mean + std, n)
         py = [p([i]) for i in y]
         self.assertTrue(np.all(py[1:] <= py[:-1]))
 
-        # Test sampling
+    def test_normal_prior_sampling(self):
+        mean = 10
+        std = 2
+        p = pints.NormalLogPrior(mean, std)
+
         d = 1
         n = 1
         x = p.sample(n)
@@ -41,6 +45,13 @@ class TestPrior(unittest.TestCase):
         n = 10
         x = p.sample(n)
         self.assertEqual(x.shape, (n, d))
+
+        # Very roughly check distribution (main checks are in numpy!)
+        np.random.seed(1)
+        p = pints.NormalLogPrior(mean, std)
+        x = p.sample(10000)
+        self.assertTrue(np.abs(mean - x.mean(axis=0)) < 0.1)
+        self.assertTrue(np.abs(std - x.std(axis=0)) < 0.01)
 
     def test_composed_prior(self):
         import pints
@@ -74,7 +85,16 @@ class TestPrior(unittest.TestCase):
         p = [f([m1, m2]) for f in p]
         self.assertTrue(np.all(p[:-1] > p[1:]))
 
-        # Test sampling
+    def test_composed_prior_sampling(self):
+
+        m1 = 10
+        c1 = 2
+        p1 = pints.NormalLogPrior(m1, c1)
+        m2 = -50
+        c2 = 100
+        p2 = pints.NormalLogPrior(m2, c2)
+        p = pints.ComposedLogPrior(p1, p2)
+
         p = pints.ComposedLogPrior(p1, p2)
         d = 2
         n = 1
@@ -124,7 +144,12 @@ class TestPrior(unittest.TestCase):
         self.assertEqual(p([5, 5]), w)
         self.assertEqual(p([5, 20 - 1e-14]), w)
 
-        # Test sampling
+    def test_uniform_prior_sampling(self):
+        lower = np.array([1, 2])
+        upper = np.array([10, 20])
+        p = pints.UniformLogPrior(lower, upper)
+
+        # Test output formats
         d = 2
         n = 1
         x = p.sample(n)
@@ -142,9 +167,17 @@ class TestPrior(unittest.TestCase):
         x = p.sample(n)
         self.assertEqual(x.shape, (n, d))
 
+        # Roughly check distribution (main checks are in numpy!)
+        np.random.seed(1)
+        p = pints.UniformLogPrior(lower, upper)
+        x = p.sample(10000)
+        self.assertTrue(np.all(lower <= x))
+        self.assertTrue(np.all(upper > x))
+        self.assertTrue(
+            np.linalg.norm(x.mean(axis=0) - 0.5 * (upper + lower)) < 0.1)
+
     def test_multivariate_normal_prior(self):
         # 1d test
-        d = 1
         mean = 0
         covariance = 1
 
@@ -162,7 +195,20 @@ class TestPrior(unittest.TestCase):
         p([-1])
         p([11])
 
-        # Test sampling
+        # 5d tests
+        mean = [1, 2, 3, 4, 5]
+        covariance = np.diag(mean)
+        p = pints.MultivariateNormalLogPrior(mean, covariance)
+        self.assertRaises(ValueError, p, [1, 2, 3])
+        p([1, 2, 3, 4, 5])
+        p([-1, 2, -3, 4, -5])
+
+    def test_multivariate_normal_sampling(self):
+        d = 1
+        mean = 2
+        covariance = [[1]]
+        p = pints.MultivariateNormalLogPrior(mean, covariance)
+
         n = 1
         x = p.sample(n)
         self.assertEqual(x.shape, (n, d))
@@ -172,20 +218,23 @@ class TestPrior(unittest.TestCase):
 
         # 5d tests
         d = 5
-        mean = [1, 2, 3, 4, 5]
+        mean = np.array([1, 2, 3, 4, 5])
         covariance = np.diag(mean)
         p = pints.MultivariateNormalLogPrior(mean, covariance)
-        self.assertRaises(ValueError, p, [1, 2, 3])
-        p([1, 2, 3, 4, 5])
-        p([-1, 2, -3, 4, -5])
-
-        # Test sampling in 5-d
         n = 1
         x = p.sample(n)
         self.assertEqual(x.shape, (n, d))
         n = 10
         x = p.sample(n)
         self.assertEqual(x.shape, (n, d))
+
+        # Roughly check distribution (main checks are in numpy!)
+        np.random.seed(1)
+        p = pints.MultivariateNormalLogPrior(mean, covariance)
+        x = p.sample(10000)
+        self.assertTrue(np.all(np.abs(mean - x.mean(axis=0)) < 0.1))
+        self.assertTrue(np.all(
+            np.abs(np.diag(covariance) - x.std(axis=0)**2) < 0.1))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The LogPrior classes needed tests, and not all of them had the new `sample()` method.

See #200 