### PR TITLE
i43 sensitivities: A third proposal

### DIFF
--- a/docs/source/core_classes_and_methods.rst
+++ b/docs/source/core_classes_and_methods.rst
@@ -12,7 +12,7 @@ Forward model
 Forward model with sensitivities
 ********************************
 
-.. autoclass:: ForwardModelWithSensitivities
+.. autoclass:: ForwardModelS1
 
 Problems
 ********

--- a/pints/__init__.py
+++ b/pints/__init__.py
@@ -41,7 +41,7 @@ FLOAT_FORMAT = '{: .17e}'
 #
 # Core classes
 #
-from ._core import ForwardModel, ForwardModelWithSensitivities
+from ._core import ForwardModel, ForwardModelS1
 from ._core import SingleOutputProblem, MultiOutputProblem
 
 #

--- a/pints/_core.py
+++ b/pints/_core.py
@@ -46,8 +46,9 @@ class ForwardModel(object):
             value appears in ``times``.
 
         Returns:
-            A numpy array of length ``t`` representing the values of the model
-            at the given time points, where ``t`` is the number of time points.
+
+        A numpy array of length ``len(times)`` representing the values of the
+        model at the given ``times``.
 
         Note: For efficiency, both ``parameters`` and ``times`` will be passed
         in as read-only numpy arrays.
@@ -61,18 +62,19 @@ class ForwardModel(object):
         return 1
 
 
-class ForwardModelWithSensitivities(ForwardModel):
+class ForwardModelS1(ForwardModel):
     """
-    Defines an interface for user-supplied forward models which can
-    (optionally) provide sensitivities.
+    Defines an interface for user-supplied forward models which can calculate
+    the first-order derivative of the simulated values with respect to the
+    parameters.
 
     Derived from :class:`pints.ForwardModel`.
     """
 
     def __init__(self):
-        super(ForwardModelWithSensitivities, self).__init__()
+        super(ForwardModelS1, self).__init__()
 
-    def simulate_with_sensitivities(self, parameters, times):
+    def simulateS1(self, parameters, times):
         """
         Runs a forward simulation with the given ``parameters`` and returns a
         time-series with data points corresponding to the given ``times``,
@@ -90,13 +92,14 @@ class ForwardModelWithSensitivities(ForwardModel):
             value appears in ``times``.
 
         Returns:
-            A tuple of 2 numpy arrays. The first is a 1d array of length ``t``
-            representing the values of the model at the given time points. The
-            second is a 2d numpy array of size ``(t,p)``, where ``p`` is the
-            number of parameters
 
-        Note: For efficiency, both ``parameters`` and ``times`` will be passed
-        in as read-only numpy arrays.
+        A tuple ``(y, y')`` of the simulated values ``y`` and their derivatives
+        ``y'`` with resepect to the ``parameters``.
+        The first entry ``y`` must be a sequence of ``n_times`` values, or
+        a NumPy array of shape ``(n_times, n_outputs)``.
+        The second entry ``y'`` must be a numpy array of shape
+        ``(n_times, n_parameters)`` or an array of shape
+        ``(n_times, n_outputs, n_parameters)``.
         """
         raise NotImplementedError
 
@@ -152,6 +155,19 @@ class SingleOutputProblem(object):
         values.
         """
         return self._model.simulate(parameters, self._times)
+
+    def evaluateS1(self, parameters):
+        """
+        Runs a simulation with first-order sensitivity calculation, returning
+        the simulated values and derivatives.
+
+        The returned data is a tuple ``(y, y')``, where ``y`` is a sequence of
+        length ``n_times``, while ``y'`` has shape ``(n_times, n_parameters)``.
+
+        *This method only works for problems whose model implements the
+        :class:`ForwardModelS1` interface.*
+        """
+        return self._model.simulateS1(parameters, self._times)
 
     def n_outputs(self):
         """
@@ -239,6 +255,22 @@ class MultiOutputProblem(object):
         """
         Runs a simulation using the given parameters, returning the simulated
         values.
+
+        The returned data has shape ``(n_times, n_outputs)``.
+        """
+        return self._model.simulate(parameters, self._times)
+
+    def evaluateS1(self, parameters):
+        """
+        Runs a simulation using the given parameters, returning the simulated
+        values.
+
+        The returned data is a tuple ``(y, y')``, where ``y`` has shape
+        ``(n_times, n_outputs)``, while ``y'`` has shape
+        ``(n_times, n_outputs, n_parameters)``.
+
+        *This method only works for problems whose model implements the
+        :class:`ForwardModelS1` interface.*
         """
         return self._model.simulate(parameters, self._times)
 

--- a/pints/_core.py
+++ b/pints/_core.py
@@ -272,7 +272,7 @@ class MultiOutputProblem(object):
         *This method only works for problems whose model implements the
         :class:`ForwardModelS1` interface.*
         """
-        return self._model.simulate(parameters, self._times)
+        return self._model.simulateS1(parameters, self._times)
 
     def n_outputs(self):
         """

--- a/pints/_error_measures.py
+++ b/pints/_error_measures.py
@@ -56,8 +56,9 @@ class ProblemErrorMeasure(ErrorMeasure):
         self._problem = problem
         self._times = problem.times()
         self._values = problem.values()
-        self._n_parameters = problem.n_parameters()
         self._n_outputs = problem.n_outputs()
+        self._n_parameters = problem.n_parameters()
+        self._n_times = len(self._times)
 
     def n_parameters(self):
         """ See :meth:`ErrorMeasure.n_parameters()`. """
@@ -264,4 +265,13 @@ class SumOfSquaresError(ProblemErrorMeasure):
     """
     def __call__(self, x):
         return np.sum((self._problem.evaluate(x) - self._values)**2)
+
+    def evaluateS1(self, x):
+        """ See :meth:`ErrorMeasure.evaluateS1()`. """
+        y, dy = self._problem.evaluateS1(x)
+        dy = dy.reshape((self._n_times, self._n_outputs, self._n_parameters))
+        r = y - self._values
+        e = np.sum(r**2)
+        de = 2 * np.sum((r.T * dy.T), axis=(1, 2))
+        return e, de
 

--- a/pints/_error_measures.py
+++ b/pints/_error_measures.py
@@ -223,6 +223,15 @@ class MeanSquaredError(ProblemErrorMeasure):
         return (np.sum((self._problem.evaluate(x) - self._values)**2) *
                 self._ninv)
 
+    def evaluateS1(self, x):
+        """ See :meth:`ErrorMeasure.evaluateS1()`. """
+        y, dy = self._problem.evaluateS1(x)
+        dy = dy.reshape((self._n_times, self._n_outputs, self._n_parameters))
+        r = y - self._values
+        e = self._ninv * np.sum(r**2)
+        de = 2 * np.sum((r.T * dy.T), axis=(1, 2))
+        return e, de
+
 
 class RootMeanSquaredError(ProblemErrorMeasure):
     """

--- a/pints/_error_measures.py
+++ b/pints/_error_measures.py
@@ -229,7 +229,7 @@ class MeanSquaredError(ProblemErrorMeasure):
         dy = dy.reshape((self._n_times, self._n_outputs, self._n_parameters))
         r = y - self._values
         e = self._ninv * np.sum(r**2)
-        de = 2 * np.sum((r.T * dy.T), axis=(1, 2))
+        de = 2 * self._ninv * np.sum((r.T * dy.T), axis=(1, 2))
         return e, de
 
 

--- a/pints/_error_measures.py
+++ b/pints/_error_measures.py
@@ -25,6 +25,18 @@ class ErrorMeasure(object):
     def __call__(self, x):
         raise NotImplementedError
 
+    def evaluateS1(self, x):
+        """
+        Evaluates this error measure, and returns the result plus the partial
+        derivatives of the result with respect to the parameters.
+
+        The returned data has the shape ``(e, e')`` where ``e`` is a scalar
+        value and ``e'`` is a sequence of length ``n_parameters``.
+
+        *This is an optional method that is not always implemented.*
+        """
+        raise NotImplementedError
+
     def n_parameters(self):
         """
         Returns the dimension of the parameter space this measure is defined
@@ -44,12 +56,12 @@ class ProblemErrorMeasure(ErrorMeasure):
         self._problem = problem
         self._times = problem.times()
         self._values = problem.values()
-        self._dimension = problem.n_parameters()
+        self._n_parameters = problem.n_parameters()
         self._n_outputs = problem.n_outputs()
 
     def n_parameters(self):
         """ See :meth:`ErrorMeasure.n_parameters()`. """
-        return self._dimension
+        return self._n_parameters
 
 
 class ProbabilityBasedError(ErrorMeasure):
@@ -72,12 +84,22 @@ class ProbabilityBasedError(ErrorMeasure):
                 'Given log_pdf must be an instance of pints.LogPDF.')
         self._log_pdf = log_pdf
 
+    def __call__(self, x):
+        return -self._log_pdf(x)
+
+    def evaluateS1(self, x):
+        """
+        See :meth:`ErrorMeasure.evaluateS1()`.
+
+        *This method only works if the underlying :class:`LogPDF`
+        implements the optional method :meth:`LogPDF.evaluateS1()`!*
+        """
+        y, dy = self._log_pdf.evaluateS1(x)
+        return -y, -np.asarray(dy)
+
     def n_parameters(self):
         """ See :meth:`ErrorMeasure.n_parameters()`. """
         return self._log_pdf.n_parameters()
-
-    def __call__(self, x):
-        return -self._log_pdf(x)
 
 
 class SumOfErrors(ErrorMeasure):
@@ -138,9 +160,9 @@ class SumOfErrors(ErrorMeasure):
 
         # Get and check dimension
         i = iter(self._errors)
-        self._dimension = next(i).n_parameters()
+        self._n_parameters = next(i).n_parameters()
         for e in i:
-            if e.n_parameters() != self._dimension:
+            if e.n_parameters() != self._n_parameters:
                 raise ValueError(
                     'All errors passed to SumOfErrors must have same'
                     ' dimension.')
@@ -148,16 +170,34 @@ class SumOfErrors(ErrorMeasure):
         # Check weights
         self._weights = [float(w) for w in weights]
 
-    def n_parameters(self):
-        """ See :meth:`ErrorMeasure.n_parameters()`. """
-        return self._dimension
-
     def __call__(self, x):
         i = iter(self._weights)
         total = 0
         for e in self._errors:
             total += e(x) * next(i)
         return total
+
+    def evaluateS1(self, x):
+        """
+        See :meth:`ErrorMeasure.evaluateS1()`.
+
+        *This method only works if all the underlying :class:`ErrorMeasure`
+        objects implement the optional method
+        :meth:`ErrorMeasure.evaluateS1()`!*
+        """
+        i = iter(self._weights)
+        total = 0
+        dtotal = np.zeros(self._n_parameters)
+        for e in self._errors:
+            w = next(i)
+            a, b = e.evaluateS1(x)
+            total += w * a
+            dtotal += w * np.asarray(b)
+        return total, dtotal
+
+    def n_parameters(self):
+        """ See :meth:`ErrorMeasure.n_parameters()`. """
+        return self._n_parameters
 
 
 class MeanSquaredError(ProblemErrorMeasure):

--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -141,7 +141,7 @@ class UnknownNoiseLogLikelihood(pints.ProblemLogLikelihood):
         self._no = problem.n_outputs()
 
         # Add parameters to problem
-        self._dimension = problem.n_parameters() + self._no
+        self._n_parameters = problem.n_parameters() + self._no
 
         # Pre-calculate parts
         self._logn = 0.5 * self._nt * np.log(2 * np.pi)
@@ -190,7 +190,7 @@ class StudentTLogLikelihood(pints.ProblemLogLikelihood):
         self._no = problem.n_outputs()
 
         # Add parameters to problem (two for each output)
-        self._dimension = problem.n_parameters() + 2 * self._no
+        self._n_parameters = problem.n_parameters() + 2 * self._no
 
         # Pre-calculate
         self._n = len(self._times)
@@ -312,9 +312,9 @@ class SumOfIndependentLogLikelihoods(pints.LogLikelihood):
 
         # Get and check dimension
         i = iter(self._log_likelihoods)
-        self._dimension = next(i).n_parameters()
+        self._n_parameters = next(i).n_parameters()
         for e in i:
-            if e.n_parameters() != self._dimension:
+            if e.n_parameters() != self._n_parameters:
                 raise ValueError(
                     'All log-likelihoods passed to'
                     ' SumOfIndependentLogLikelihoods must have same'
@@ -343,5 +343,5 @@ class SumOfIndependentLogLikelihoods(pints.LogLikelihood):
 
     def n_parameters(self):
         """ See :meth:`LogPDF.n_parameters()`. """
-        return self._dimension
+        return self._n_parameters
 

--- a/pints/_log_pdfs.py
+++ b/pints/_log_pdfs.py
@@ -16,11 +16,26 @@ class LogPDF(object):
     probability density function (PDF).
 
     All :class:`LogPDF` types are callable: when called with a vector argument
-    ``theta`` they return some value ``log(f(theta))`` where ``f(theta)`` is an
-    unnormalised PDF. The size of the argument `theta` is given by
+    ``p`` they return some value ``log(f(p))`` where ``f(p)`` is an
+    unnormalised PDF. The size of the argument ``p`` is given by
     :meth:`n_parameters()`.
     """
     def __call__(self, x):
+        raise NotImplementedError
+
+    def evaluateS1(self, x):
+        """
+        Evaluates this LogPDF, and returns the result plus the partial
+        derivatives of the result with respect to the parameters.
+
+        The returned data has the shape ``(L, L')`` where ``L`` is a scalar
+        value and ``L'`` is a sequence of length ``n_parameters``.
+
+        Note that the derivative returned is of the loglikelihood, so
+        ``L' = d/dp log(f(p))``, evaluated at ``p=x``.
+
+        *This is an optional method that is not always implemented.*
+        """
         raise NotImplementedError
 
     def n_parameters(self):
@@ -110,7 +125,6 @@ class LogPosterior(LogPDF):
         A :class:`LogPrior`, representing prior knowledge of the parameter
         space.
 
-
     """
     def __init__(self, log_likelihood, log_prior):
         super(LogPosterior, self).__init__()
@@ -142,6 +156,23 @@ class LogPosterior(LogPDF):
         if log_prior == self._minf:
             return self._minf
         return log_prior + self._log_likelihood(x)
+
+    def evaluateS1(self, x):
+        """
+        Evaluates this LogPDF, and returns the result plus the partial
+        derivatives of the result with respect to the parameters.
+
+        The returned data has the shape ``(L, L')`` where ``L`` is a scalar
+        value and ``L'`` is a sequence of length ``n_parameters``.
+
+        *This method only works if the underlying :class:`LogLikelihood` and
+        :class:`LogPrior` implement the optional method
+        :meth:`LogPDF.evaluateS1()`!*
+        """
+        #TODO: Is there an optimisation to be made here?
+        a, da = self._log_prior.evaluateS1(x)
+        b, db = self._log_likelihood.evaluateS1(x)
+        return a + b, da + db
 
     def n_parameters(self):
         """ See :meth:`LogPDF.n_parameters()`. """

--- a/pints/_log_pdfs.py
+++ b/pints/_log_pdfs.py
@@ -99,11 +99,11 @@ class ProblemLogLikelihood(LogLikelihood):
         # Cache some problem variables
         self._values = problem.values()
         self._times = problem.times()
-        self._dimension = problem.n_parameters()
+        self._n_parameters = problem.n_parameters()
 
     def n_parameters(self):
         """ See :meth:`LogPDF.n_parameters()`. """
-        return self._dimension
+        return self._n_parameters
 
 
 class LogPosterior(LogPDF):
@@ -138,8 +138,8 @@ class LogPosterior(LogPDF):
                 'Given log_likelihood must extend pints.LogLikelihood.')
 
         # Check dimensions
-        self._dimension = log_prior.n_parameters()
-        if log_likelihood.n_parameters() != self._dimension:
+        self._n_parameters = log_prior.n_parameters()
+        if log_likelihood.n_parameters() != self._n_parameters:
             raise ValueError(
                 'Given log_prior and log_likelihood must have same dimension.')
 
@@ -176,5 +176,5 @@ class LogPosterior(LogPDF):
 
     def n_parameters(self):
         """ See :meth:`LogPDF.n_parameters()`. """
-        return self._dimension
+        return self._n_parameters
 

--- a/pints/_log_priors.py
+++ b/pints/_log_priors.py
@@ -68,7 +68,7 @@ class ComposedLogPrior(pints.LogPrior):
             hi += prior.n_parameters()
             p, dp = prior.evaluateS1(x[lo:hi])
             output += p
-            doutput += np.asarray(dp)
+            doutput[lo:hi] = np.asarray(dp)
         return output, doutput
 
     def n_parameters(self):
@@ -154,6 +154,7 @@ class NormalLogPrior(pints.LogPrior):
         return self._offset - self._factor * (x[0] - self._mean)**2
 
     def evaluateS1(self, x):
+        """ See :meth:`LogPDF.evaluateS1()`. """
         return self(x), self._factor2 * (self._mean - np.asarray(x))
 
     def n_parameters(self):

--- a/pints/_log_priors.py
+++ b/pints/_log_priors.py
@@ -148,9 +148,13 @@ class NormalLogPrior(pints.LogPrior):
         # Cache constants
         self._offset = 1 / np.sqrt(2 * np.pi * self._sigma ** 2)
         self._factor = 1 / (2 * self._sigma ** 2)
+        self._factor2 = 1 / self._sigma**2
 
     def __call__(self, x):
         return self._offset - self._factor * (x[0] - self._mean)**2
+
+    def evaluateS1(self, x):
+        return self(x), self._factor2 * (self._mean - np.asarray(x))
 
     def n_parameters(self):
         """ See :meth:`LogPrior.n_parameters()`. """

--- a/pints/_log_priors.py
+++ b/pints/_log_priors.py
@@ -256,7 +256,7 @@ class UniformLogPrior(pints.LogPrior):
         # Ignoring points on the boundaries (i.e. on the surface of the
         # hypercube), because it's very unlikely and won't help the search
         # much...
-        return self(x), 0
+        return self(x), np.zeros(self._n_parameters)
 
     def n_parameters(self):
         """ See :meth:`LogPrior.n_parameters()`. """

--- a/pints/toy/_constant_model.py
+++ b/pints/toy/_constant_model.py
@@ -12,9 +12,9 @@ import numpy as np
 import pints
 
 
-class ConstantModel(pints.ForwardModel):
+class ConstantModel(pints.ForwardModelS1):
     """
-    *Extends:* :class:`pints.ForwardModel`.
+    *Extends:* :class:`pints.ForwardModelS1`.
 
     Toy model that's constant over time, linear over the parameters.
 
@@ -86,3 +86,11 @@ class ConstantModel(pints.ForwardModel):
             out = out.reshape((len(times), ))
         return out
 
+    def simulateS1(self, parameters, times):
+        """ See :meth:`pints.ForwardModel.simulateS1()`. """
+        y = self.simulate(parameters, times)
+        if self._n == 1:
+            dy = np.ones(self._n)
+        else:
+            dy = np.ones((self._n, self._n))
+        return (y, dy)

--- a/pints/toy/_constant_model.py
+++ b/pints/toy/_constant_model.py
@@ -90,7 +90,7 @@ class ConstantModel(pints.ForwardModelS1):
         """ See :meth:`pints.ForwardModel.simulateS1()`. """
         y = self.simulate(parameters, times)
         if self._n == 1:
-            dy = np.ones(self._n)
+            dy = np.ones(len(times))
         else:
-            dy = np.ones((self._n, self._n))
+            dy = np.ones((len(times), self._n, self._n))
         return (y, dy)

--- a/pints/toy/_fitzhugh_nagumo_model.py
+++ b/pints/toy/_fitzhugh_nagumo_model.py
@@ -14,7 +14,7 @@ import pints
 from scipy.integrate import odeint
 
 
-class FitzhughNagumoModel(pints.ForwardModelWithSensitivities):
+class FitzhughNagumoModel(pints.ForwardModelS1):
     """
     Fitzhugh Nagumo model of action potential.
 
@@ -72,9 +72,11 @@ class FitzhughNagumoModel(pints.ForwardModelWithSensitivities):
         return 2
 
     def simulate(self, parameters, times):
+        """ See :meth:`pints.ForwardModel.simulate()`. """
         return self._simulate(parameters, times, False)
 
-    def simulate_with_sensitivities(self, parameters, times):
+    def simulateS1(self, parameters, times):
+        """ See :meth:`pints.ForwardModelS1.simulateS1()`. """
         return self._simulate(parameters, times, True)
 
     def _simulate(self, parameters, times, sensitivities):

--- a/pints/toy/_fitzhugh_nagumo_model.py
+++ b/pints/toy/_fitzhugh_nagumo_model.py
@@ -153,3 +153,16 @@ class FitzhughNagumoModel(pints.ForwardModelS1):
         else:
             values = odeint(r, self._y0, times, (parameters,))
             return values
+
+    def suggested_parameters(self):
+        """
+        Returns a suggested set of parameters for this toy model.
+        """
+        return np.array([0.1, 0.5, 3])
+
+    def suggested_times(self):
+        """
+        Returns a suggested set of simulation times for this toy model.
+        """
+        return np.linspace(0, 20, 200)
+

--- a/pints/toy/_logistic_model.py
+++ b/pints/toy/_logistic_model.py
@@ -12,10 +12,8 @@ import numpy as np
 import pints
 
 
-class LogisticModel(pints.ForwardModelWithSensitivities):
+class LogisticModel(pints.ForwardModelS1):
     """
-    *Extends:* :class:`pints.ForwardModel`.
-
     Logistic model of population growth [1].
 
     .. math::
@@ -44,9 +42,11 @@ class LogisticModel(pints.ForwardModelWithSensitivities):
         return 2
 
     def simulate(self, parameters, times):
+        """ See :meth:`pints.ForwardModel.simulate()`. """
         return self._simulate(parameters, times, False)
 
-    def simulate_with_sensitivities(self, parameters, times):
+    def simulateS1(self, parameters, times):
+        """ See :meth:`pints.ForwardModelS1.simulateS1()`. """
         return self._simulate(parameters, times, True)
 
     def _simulate(self, parameters, times, sensitivities):

--- a/test/test_constant_model.py
+++ b/test/test_constant_model.py
@@ -110,7 +110,7 @@ class TestConstantModel(unittest.TestCase):
         problem = pints.SingleOutputProblem(model, times, values)
         x = [3]
         y, dy = problem.evaluateS1(x)
-        self.assertEqual(dy.shape, (1, ))
+        self.assertEqual(dy.shape, (4, ))
         self.assertTrue(np.all(dy == 1))
         self.assertTrue(np.all(y == problem.evaluate(x)))
 
@@ -121,7 +121,7 @@ class TestConstantModel(unittest.TestCase):
         problem = pints.MultiOutputProblem(model, times, values)
         x = [3, 4]
         y, dy = problem.evaluateS1(x)
-        self.assertEqual(dy.shape, (2, 2))
+        self.assertEqual(dy.shape, (4, 2, 2))
         self.assertTrue(np.all(dy == 1))
         self.assertTrue(np.all(y == problem.evaluate(x)))
 

--- a/test/test_constant_model.py
+++ b/test/test_constant_model.py
@@ -68,13 +68,16 @@ class TestConstantModel(unittest.TestCase):
         times = [0, -1, 2, 10000]
         self.assertRaises(ValueError, model.simulate, [1], times)
         times = [0, 1, 2, 10000]
+
         # Wrong number of parameters
         self.assertRaises(ValueError, model.simulate, [], times)
         self.assertRaises(ValueError, model.simulate, [1, 1], times)
+
         # Non-finite parameters
         self.assertRaises(ValueError, model.simulate, [np.nan], times)
         self.assertRaises(ValueError, model.simulate, [np.inf], times)
         self.assertRaises(ValueError, model.simulate, [-np.inf], times)
+
         # Invalid number of parameters
         self.assertRaises(ValueError, pints.toy.ConstantModel, 0)
         self.assertRaises(ValueError, pints.toy.ConstantModel, -1)
@@ -86,15 +89,41 @@ class TestConstantModel(unittest.TestCase):
         values = [10, 0, 1, 10]
         problem = pints.SingleOutputProblem(model, times, values)
         problem.evaluate([1])
+
         # Multi output (n=1)
         problem = pints.MultiOutputProblem(model, times, values)
         problem.evaluate([1])
+
         # Multi output (n=3)
         model = pints.toy.ConstantModel(3)
         times = [0, 1, 2, 1000]
         values = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [8, 7, 6]]
         problem = pints.MultiOutputProblem(model, times, values)
         problem.evaluate([1, 2, 3])
+
+    def test_derivatives(self):
+
+        # Single output
+        model = pints.toy.ConstantModel(1)
+        times = [0, 1, 2, 1000]
+        values = [10, 0, 1, 10]
+        problem = pints.SingleOutputProblem(model, times, values)
+        x = [3]
+        y, dy = problem.evaluateS1(x)
+        self.assertEqual(dy.shape, (1, ))
+        self.assertTrue(np.all(dy == 1))
+        self.assertTrue(np.all(y == problem.evaluate(x)))
+
+        # Multi-output
+        model = pints.toy.ConstantModel(2)
+        times = [0, 1, 2, 1000]
+        values = [[0, 0], [1, 10], [2, 20], [3, 30]]
+        problem = pints.MultiOutputProblem(model, times, values)
+        x = [3, 4]
+        y, dy = problem.evaluateS1(x)
+        self.assertEqual(dy.shape, (2, 2))
+        self.assertTrue(np.all(dy == 1))
+        self.assertTrue(np.all(y == problem.evaluate(x)))
 
 
 if __name__ == '__main__':

--- a/test/test_error_measures.py
+++ b/test/test_error_measures.py
@@ -318,6 +318,7 @@ class TestErrorMeasures(unittest.TestCase):
         y2, dy2 = e2.evaluateS1(x)
         self.assertTrue(np.all(dy == dy1 + 2 * dy2))
 
+
 if __name__ == '__main__':
     print('Add -v for more debug output')
     import sys

--- a/test/test_error_measures.py
+++ b/test/test_error_measures.py
@@ -92,6 +92,9 @@ class MiniLogPDF(pints.LogPDF):
     def __call__(self, parameters):
         return 10
 
+    def evaluateS1(self, parameters):
+        return 10, np.array([1, 2, 3])
+
 
 class TestErrorMeasures(unittest.TestCase):
     """
@@ -134,6 +137,13 @@ class TestErrorMeasures(unittest.TestCase):
         self.assertEqual(e([1, 2, 3]), -10)
         p = MiniProblem()
         self.assertRaises(ValueError, pints.ProbabilityBasedError, p)
+
+        # Test derivatives
+        x = [1, 2, 3]
+        y, dy = e.evaluateS1(x)
+        self.assertEqual(y, e(x))
+        self.assertEqual(dy.shape, (3, ))
+        self.assertTrue(np.all(dy == [-1, -2, -3]))
 
     def test_root_mean_squared_error(self):
         p = MiniProblem()

--- a/test/test_fitzhugh_nagumo_model.py
+++ b/test/test_fitzhugh_nagumo_model.py
@@ -19,16 +19,19 @@ class TestFitzhughNagumoModel(unittest.TestCase):
 
     def test_run(self):
 
+        # Test basic properties
         model = pints.toy.FitzhughNagumoModel()
         self.assertEqual(model.n_parameters(), 3)
         self.assertEqual(model.n_outputs(), 2)
 
+        # Test simulation
         x = [1, 1, 1]
         times = [1, 2, 3, 4]
         values = model.simulate(x, times)
         self.assertEqual(values.shape, (len(times), 2))
 
-        values, dvalues_dp = model.simulate_with_sensitivities(x, times)
+        # Simulation with sensitivities
+        values, dvalues_dp = model.simulateS1(x, times)
         self.assertEqual(values.shape, (len(times), 2))
         self.assertEqual(dvalues_dp.shape, (len(times), 2, 3))
 
@@ -37,9 +40,12 @@ class TestFitzhughNagumoModel(unittest.TestCase):
         values = model.simulate(x, times)
         self.assertEqual(values.shape, (len(times), 2))
 
-        # Test errors
+        # Times can't be negative
         times = [-1, 2, 3, 4]
         self.assertRaises(ValueError, model.simulate, x, times)
+
+        # Initial value must have size 2
+        pints.toy.FitzhughNagumoModel([1, 1])
         self.assertRaises(ValueError, pints.toy.FitzhughNagumoModel, [1])
 
 

--- a/test/test_fitzhugh_nagumo_model.py
+++ b/test/test_fitzhugh_nagumo_model.py
@@ -25,8 +25,8 @@ class TestFitzhughNagumoModel(unittest.TestCase):
         self.assertEqual(model.n_outputs(), 2)
 
         # Test simulation
-        x = [1, 1, 1]
-        times = [1, 2, 3, 4]
+        x = model.suggested_parameters()
+        times = model.suggested_times()
         values = model.simulate(x, times)
         self.assertEqual(values.shape, (len(times), 2))
 

--- a/test/test_log_posterior.py
+++ b/test/test_log_posterior.py
@@ -52,6 +52,18 @@ class TestLogPosterior(unittest.TestCase):
         y2, dy2 = loglikelihood.evaluateS1(x)
         self.assertTrue(np.all(dy == dy1 + dy2))
 
+        # First arg must be LogLikelihood
+        self.assertRaises(ValueError, pints.LogPosterior, logprior, logprior)
+
+        # Second arg must be LogPrior
+        self.assertRaises(
+            ValueError, pints.LogPosterior, loglikelihood, loglikelihood)
+
+        # Prior and likelihood must have same dimension
+        self.assertRaises(
+            ValueError, pints.LogPosterior, loglikelihood,
+            pints.NormalLogPrior(0.015, 0.3))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_log_posterior.py
+++ b/test/test_log_posterior.py
@@ -39,6 +39,19 @@ class TestLogPosterior(unittest.TestCase):
         self.assertEqual(p(y), -float('inf'))
         self.assertEqual(p(y), logprior(y))
 
+        # Test derivatives
+        logprior = pints.ComposedLogPrior(
+            pints.NormalLogPrior(0.015, 0.3),
+            pints.NormalLogPrior(500, 100))
+        logposterior = pints.LogPosterior(loglikelihood, logprior)
+        x = [0.013, 540]
+        y, dy = logposterior.evaluateS1(x)
+        self.assertEqual(y, logposterior(x))
+        self.assertEqual(dy.shape, (2, ))
+        y1, dy1 = logprior.evaluateS1(x)
+        y2, dy2 = loglikelihood.evaluateS1(x)
+        self.assertTrue(np.all(dy == dy1 + dy2))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_log_priors.py
+++ b/test/test_log_priors.py
@@ -97,7 +97,15 @@ class TestPrior(unittest.TestCase):
         self.assertRaises(ValueError, pints.ComposedLogPrior, 1)
 
         # Test derivatives
-        #TODO
+        p = pints.ComposedLogPrior(p1, p2)
+        x = [8, -40]
+        y, dy = p.evaluateS1(x)
+        self.assertEqual(y, p(x))
+        self.assertEqual(dy.shape, (2, ))
+        y1, dy1 = p1.evaluateS1(x[:1])
+        y2, dy2 = p2.evaluateS1(x[1:])
+        self.assertAlmostEqual(dy[0], dy1[0])
+        self.assertAlmostEqual(dy[1], dy2[0])
 
     def test_composed_prior_sampling(self):
 

--- a/test/test_log_priors.py
+++ b/test/test_log_priors.py
@@ -173,6 +173,19 @@ class TestPrior(unittest.TestCase):
         self.assertEqual(p([5, 5]), w)
         self.assertEqual(p([5, 20 - 1e-14]), w)
 
+        # Test derivatives (always 0)
+        for x in [[0, 0], [0, 5], [0, 19], [0, 21], [5, 0], [5, 21]]:
+            y, dy = p.evaluateS1(x)
+            self.assertEqual(y, p(x))
+            self.assertEqual(dy.shape, (2, ))
+            self.assertTrue(np.all(dy == 0))
+
+        for x in [[1, 2], [1, 5], [1, 20 - 1e-14], [5, 5], [5, 20 - 1e-14]]:
+            y, dy = p.evaluateS1(x)
+            self.assertEqual(y, p(x))
+            self.assertEqual(dy.shape, (2, ))
+            self.assertTrue(np.all(dy == 0))
+
         # Test bad constructor
         self.assertRaises(ValueError, pints.UniformLogPrior, lower)
 

--- a/test/test_log_priors.py
+++ b/test/test_log_priors.py
@@ -33,6 +33,13 @@ class TestPrior(unittest.TestCase):
         py = [p([i]) for i in y]
         self.assertTrue(np.all(py[1:] <= py[:-1]))
 
+        # Test derivatives
+        x = [8]
+        y, dy = p.evaluateS1(x)
+        self.assertEqual(y, p(x))
+        self.assertEqual(dy.shape, (1, ))
+        self.assertEqual(dy[0], (mean - x[0]) / std**2)
+
     def test_normal_prior_sampling(self):
         mean = 10
         std = 2
@@ -88,6 +95,9 @@ class TestPrior(unittest.TestCase):
         # Test errors
         self.assertRaises(ValueError, pints.ComposedLogPrior)
         self.assertRaises(ValueError, pints.ComposedLogPrior, 1)
+
+        # Test derivatives
+        #TODO
 
     def test_composed_prior_sampling(self):
 

--- a/test/test_logistic_model.py
+++ b/test/test_logistic_model.py
@@ -53,17 +53,24 @@ class TestLogistic(unittest.TestCase):
         self.assertTrue(np.all(values == np.zeros(4)))
 
     def test_errors(self):
+
         model = pints.toy.LogisticModel(2)
-        times = [0, -1, 2, 10000]
-        parameters = [1, 0]
+
+        # Times can't be negative
+        times = [0, 1, 2, 10000]
+        parameters = [1, 1]
+        model.simulate(parameters, times)
+        times[1] = -1
         self.assertRaises(ValueError, model.simulate, parameters, times)
+
+        # Initial value can't be negative
         self.assertRaises(ValueError, pints.toy.LogisticModel, -1)
 
     def test_sensitivities(self):
         model = pints.toy.LogisticModel(2)
         times = [0, 1, 2, 10000]
         parameters = [1, 5]
-        values, dvdp = model.simulate_with_sensitivities(
+        values, dvdp = model.simulateS1(
             parameters, times)
         self.assertEqual(dvdp[0, 0], 0)
         self.assertEqual(dvdp[-1, 0], 0.0)


### PR DESCRIPTION
This one stays much closer to (basically _is_) what @martinjrobins did before, and lets users use the same LogPDF, Problem, etc. for methods with and without sensitivities (provided the used objects all support them), like @ben18785 wanted. It also allows models to implement both the `ForwardModel` and the `ForwardModelS1` class, if they want.

I've also coded up a loglikelihood with sensitivities, which wasn't fun. It did make me think that maybe we should swap the order of the multi-dimensional array indices we're using.
At the moment it's `(n_times, n_outputs)` for a multioutput problem, so `y[10]` gives you both outputs at time 10.
For sensitivities, that then becomes `(n_times, n_outputs, n_parameters)`, so that `dy[10, 2]` gives you the derivatives w.r.t p at time 10, for output 2.
That made (and makes) sense to me, and is probably how you generate the things when running simulations, but if you have a look at [this d/dp loglikelihood calculation](https://github.com/pints-team/pints/blob/i43-sensitivities-alt-2/pints/_log_likelihoods.py#L84-L86) you'll see *5* transpose operations on a single line, which makes me think we should have chosen the opposite ordering.

Would also be very grateful for any numerical examples to test with at this point. I've done some plots and they look fine. But a known example would improve our tests.

Please let me know what you think @martinjrobins @ben18785 !
If you like it, I'll try wrapping a derivative-based optimisation from scipy and test it on the logistic model, just to make sure everything works.

Then there's the long process of adding `evaluateS1` methods to all priors and loglikelihoods we've implemented!