### PR TITLE
Made optimisation show the final result if an exception occurs or the user cancels.

### DIFF
--- a/pints/_optimisers/__init__.py
+++ b/pints/_optimisers/__init__.py
@@ -463,17 +463,19 @@ class Optimisation(object):
                                     + str(iteration) + ') reached.')
 
                 # Maximum number of iterations without significant change
-                if (self._max_unchanged_iterations is not None and
-                        unchanged_iterations >= self._max_unchanged_iterations):
+                halt = (self._max_unchanged_iterations is not None and
+                        unchanged_iterations >= self._max_unchanged_iterations)
+                if halt:
                     running = False
-                    halt_message = ('Halting: No significant change for '
-                                    + str(unchanged_iterations) + ' iterations.')
+                    halt_message = ('Halting: No significant change for ' +
+                                    str(unchanged_iterations) + ' iterations.')
 
                 # Threshold value
                 if self._threshold is not None and fbest < self._threshold:
                     running = False
                     halt_message = ('Halting: Objective function crossed'
-                                    ' threshold: ' + str(self._threshold) + '.')
+                                    ' threshold: ' + str(self._threshold) +
+                                    '.')
 
                 # Error in optimiser
                 error = self._optimiser.stop()


### PR DESCRIPTION
Example:

```
Minimising error measure
using Covariance Matrix Adaptation Evolution Strategy (CMA-ES)
Running in parallel with 2 worker processes.
Population size: 10
Iter. Eval. Best      Time m:s
0     10     1.426383   0:36.3
^C
----------------------------------------
Unexpected termination.
Current best score: 1.42638335249
Current best position:
-5.03125667726224624e+00
 3.06015611698052734e-02
-2.66105137709121520e+00
 4.97419923893682517e-02
-1.06324505952824815e+01
 8.48175421713438446e-03
-1.94280811004977494e+00
 1.14010059985587588e-02
 5.69589430131492769e-01
----------------------------------------
Traceback (most recent call last):
  File "./simulation-fit.py", line 347, in <module>
    parallel=2,
  File "/home/michael/dev/pints/pints/_optimisers/__init__.py", line 885, in fmin
    return opt.run()
  File "/home/michael/dev/pints/pints/_optimisers/__init__.py", line 412, in run
    fs = evaluator.evaluate(xs)
  File "/home/michael/dev/pints/pints/_evaluation.py", line 110, in evaluate
    return self._evaluate(positions)
  File "/home/michael/dev/pints/pints/_evaluation.py", line 286, in _evaluate
    time.sleep(0.001)   # This is really necessary
KeyboardInterrupt
```

How it works:

```
try:
    # Optimisation code goes here
except (Exception, SystemExit, KeyboardInterrupt):
    # Print final status
    # re-raise the same exception, pretend nothing happened
    raise
```

As the stacktrace shows, the final `raise` command is not included in the stack trace, it just shows the stack trace for the original exception (in this example it's a `KeyboardInterrupt`).