### PR TITLE
Avoided div-by-zero in dream

### DIFF
--- a/pints/_mcmc/_dream.py
+++ b/pints/_mcmc/_dream.py
@@ -287,8 +287,11 @@ class DreamMCMC(pints.MultiChainMCMC):
                             delta[j][d] / max(self._variance[j][d], 1e-11))
 
                 self._p = self._iterations * self._chains * self._delta
-                self._p /= self._L * np.sum(self._delta)
-                self._p /= np.sum(self._p)
+                d1 = self._L * np.sum(self._delta)
+                d1[d1 == 0] += 1e-11
+                self._p /= d1
+                d2 = max(np.sum(self._p), 1e-11)
+                self._p /= d2
 
             # Update iteration count for running mean/variance
             self._iterations += 1


### PR DESCRIPTION
See #472 

@ben18785, can you have a look at the changes (just hit the "files changed" button on this PR) and tell me if you think this is ok? I'm guessing it's fine (if a little arbitrary), as `p` would have been `inf` for at least 1 iteration before...