### PR TITLE
Added traitlets and nbconvert to dev dependencies. 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@
 -r requirements-docs.txt
 flake8>=3
 jupyter
+nbconvert
+traitlets

--- a/run-tests.py
+++ b/run-tests.py
@@ -14,9 +14,7 @@ import os
 import sys
 import argparse
 import unittest
-import nbconvert
 import subprocess
-from traitlets.config import Config
 
 
 def run_unit_tests(executable=None):
@@ -172,6 +170,7 @@ def test_notebook(path, executable='python'):
     """
     Tests a single notebook, exists if it doesn't finish.
     """
+    import nbconvert
     import pints
     b = pints.Timer()
     print('Test ' + path + ' ... ', end='')
@@ -222,6 +221,9 @@ def export_notebook(ipath, opath):
     """
     Exports the notebook at `ipath` to a python file at `opath`.
     """
+    import nbconvert
+    from traitlets.config import Config
+
     # Create nbconvert configuration to ignore text cells
     c = Config()
     c.TemplateExporter.exclude_markdown = True


### PR DESCRIPTION
Made sure they're only imported when notebook tests are being run, so that non-dev users can run tests without having to install them.

Closes #544 