### PR TITLE
Value-based tests for log-likelihoods

### DIFF
--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -56,8 +56,11 @@ class AR1LogLikelihood(pints.ProblemLogLikelihood):
         self._logn = 0.5 * (self._nt) * np.log(2 * np.pi)
 
     def __call__(self, x):
-        rho = np.asarray(x[-2 * self._no:-self._no])
-        sigma = np.asarray(x[-self._no:]) * np.sqrt(1 - rho**2)
+        m = 2 * self._no
+        parameters = x[-m:]
+        rho = np.asarray(parameters[0::2])
+        sigma = np.asarray(parameters[1::2])
+        sigma = np.asarray(sigma) * np.sqrt(1 - rho**2)
         error = self._values - self._problem.evaluate(x[:-2 * self._no])
         autocorr_error = error[1:] - rho * error[:-1]
         return np.sum(- self._logn - self._nt * np.log(sigma)

--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -69,7 +69,7 @@ class AR1LogLikelihood(pints.ProblemLogLikelihood):
 
 class ARMA11LogLikelihood(pints.ProblemLogLikelihood):
     """
-    Calculates a log-likelihood assuming AR1 noise model
+    Calculates a log-likelihood assuming ARMA(1,1) noise model.
 
     .. math::
         \log{L(\\theta, \sigma|\\boldsymbol{x})} =

--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -76,14 +76,22 @@ class ARMA11LogLikelihood(pints.ProblemLogLikelihood):
             -\\frac{N}{2}\log{2\pi}
             -N\log{\sigma}
             -\\frac{1}{2\sigma^2}
-                \sum_{i=1}^N{(\\epsilon_i x_i - \\rho \\epsilon_{i-1} -
-                              \\phi \\nu(t-1))^2}
+                \sum_{i=3}^N{(\\nu_i - \\phi \\nu_{i-1})^2}
 
     where
 
     .. math::
+        \\nu_i = \\epsilon_i - \\rho \\epsilon_{i-1}
+
+    and
+
+    ..math::
         \\epsilon_i = x_i - f_i(\\theta)
 
+    and
+
+    .. math::
+        \\sigma = \\sigma\\sqrt{\\frac{1-\\rho^2}{1 + 2\\phi\\rho + \\phi^2}}`
 
     Arguments:
 
@@ -109,13 +117,16 @@ class ARMA11LogLikelihood(pints.ProblemLogLikelihood):
         self._logn = 0.5 * (self._nt) * np.log(2 * np.pi)
 
     def __call__(self, x):
-        rho = np.asarray(x[-3 * self._no:-2 * self._no])
-        phi = np.asarray(x[-2 * self._no:-self._no])
+        m = 3 * self._no
+        parameters = x[-m:]
+        rho = np.asarray(parameters[0::3])
+        phi = np.asarray(parameters[1::3])
+        sigma = np.asarray(parameters[2::3])
         sigma = (
-            np.asarray(x[-self._no:]) *
+            sigma *
             np.sqrt((1.0 - rho**2) / (1.0 + 2.0 * phi * rho + phi**2))
         )
-        error = self._values - self._problem.evaluate(x[:-3 * self._no])
+        error = self._values - self._problem.evaluate(x[:-m])
         v = error[1:] - rho * error[:-1]
         autocorr_error = v[1:] - phi * v[:-1]
         return np.sum(- self._logn - self._nt * np.log(sigma)

--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -18,16 +18,18 @@ class AR1LogLikelihood(pints.ProblemLogLikelihood):
     Calculates a log-likelihood assuming AR1 noise model
 
     .. math::
-        \log{L(\\theta, \sigma|\\boldsymbol{x})} =
+        \log{L(\\theta, \sigma'|\\boldsymbol{x})} =
             -\\frac{N}{2}\log{2\pi}
-            -N\log{\sigma}
-            -\\frac{1}{2\sigma^2}
+            -N\log{\sigma'}
+            -\\frac{1}{2\sigma'^2}
                 \sum_{i=2}^N{(\\epsilon_i x_i - \\rho \\epsilon_{i-1} )^2}
 
     where
 
     .. math::
         \\epsilon_i = x_i - f_i(\\theta)
+
+    and :math:`sigma' = \\frac{sigma} \\sqrt{1-\\rho^2}`.
 
 
     Arguments:
@@ -490,4 +492,3 @@ class UnknownNoiseLogLikelihood(GaussianLogLikelihood):
             'The class `pints.KnownNoiseLogLikelihood` is deprecated.'
             ' Please use `pints.GaussianLogLikelihood` instead.')
         super(UnknownNoiseLogLikelihood, self).__init__(problem)
-

--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -22,7 +22,7 @@ class AR1LogLikelihood(pints.ProblemLogLikelihood):
             -\\frac{N}{2}\log{2\pi}
             -N\log{\sigma}
             -\\frac{1}{2\sigma^2}
-                \sum_{i=1}^N{(\\epsilon_i x_i - \\rho \\epsilon_{i-1} )^2}
+                \sum_{i=2}^N{(\\epsilon_i x_i - \\rho \\epsilon_{i-1} )^2}
 
     where
 

--- a/pints/tests/test_error_measures.py
+++ b/pints/tests/test_error_measures.py
@@ -160,9 +160,9 @@ class TestErrorMeasures(unittest.TestCase):
         self.assertTrue(np.all(y[0, :] == [1, 4]))
         self.assertTrue(np.all(y[1, :] == [1, 4]))
         self.assertTrue(np.all(y[2, :] == [1, 4]))
-        self.assertTrue(np.all(dy[0, :] == [[1, 0], [0, 2]]))
-        self.assertTrue(np.all(dy[1, :] == [[1, 0], [0, 2]]))
-        self.assertTrue(np.all(dy[2, :] == [[1, 0], [0, 2]]))
+        self.assertTrue(np.all(dy[0, :] == [[1, 0], [0, 1]]))
+        self.assertTrue(np.all(dy[1, :] == [[1, 0], [0, 1]]))
+        self.assertTrue(np.all(dy[2, :] == [[1, 0], [0, 1]]))
 
         # Check residuals
         rx = y - np.array(values)
@@ -185,9 +185,9 @@ class TestErrorMeasures(unittest.TestCase):
         # Residuals are: [[0, 0], [-1, -3], [-2, -6]]
         # Derivatives are: [[1, 0], [0, 2]]
         # dex1 is: (2 / nt / no) * (0 - 1 - 2) * 1 = (1 / 3) * -3 * 1 = -1
-        # dex2 is: (2 / nt / no) * (0 - 3 - 6) * 2 = (1 / 3) * -9 * 2 = -6
+        # dex2 is: (2 / nt / no) * (0 - 3 - 6) * 1 = (1 / 3) * -9 * 1 = -3
         self.assertEqual(dex[0], -1)
-        self.assertEqual(dex[1], -6)
+        self.assertEqual(dex[1], -3)
 
     def test_mean_squared_error_weighted(self):
         """ Tests :class:`pints.MeanSquaredError` with weighted outputs. """
@@ -224,9 +224,9 @@ class TestErrorMeasures(unittest.TestCase):
         self.assertTrue(np.all(y[0, :] == [1, 4]))
         self.assertTrue(np.all(y[1, :] == [1, 4]))
         self.assertTrue(np.all(y[2, :] == [1, 4]))
-        self.assertTrue(np.all(dy[0, :] == [[1, 0], [0, 2]]))
-        self.assertTrue(np.all(dy[1, :] == [[1, 0], [0, 2]]))
-        self.assertTrue(np.all(dy[2, :] == [[1, 0], [0, 2]]))
+        self.assertTrue(np.all(dy[0, :] == [[1, 0], [0, 1]]))
+        self.assertTrue(np.all(dy[1, :] == [[1, 0], [0, 1]]))
+        self.assertTrue(np.all(dy[2, :] == [[1, 0], [0, 1]]))
 
         # Check residuals
         rx = y - np.array(values)
@@ -251,11 +251,11 @@ class TestErrorMeasures(unittest.TestCase):
         # dex1 is: (2 / nt / no) * (0 - 1 - 2) * 1 * 1
         #        = (1 / 3) * -3 * 1 * 1
         #        = -1
-        # dex2 is: (2 / nt / no) * (0 - 3 - 6) * 2 * 2
-        #        = (1 / 3) * -9 * 2 * 2
-        #        = -12
+        # dex2 is: (2 / nt / no) * (0 - 3 - 6) * 1 * 2
+        #        = (1 / 3) * -9 * 1 * 2
+        #        = -6
         self.assertEqual(dex[0], -1)
-        self.assertEqual(dex[1], -12)
+        self.assertEqual(dex[1], -6)
 
     def test_probability_based_error(self):
         """ Tests :class:`pints.ProbabilityBasedError`. """
@@ -350,9 +350,9 @@ class TestErrorMeasures(unittest.TestCase):
         self.assertTrue(np.all(y[0, :] == [1, 4]))
         self.assertTrue(np.all(y[1, :] == [1, 4]))
         self.assertTrue(np.all(y[2, :] == [1, 4]))
-        self.assertTrue(np.all(dy[0, :] == [[1, 0], [0, 2]]))
-        self.assertTrue(np.all(dy[1, :] == [[1, 0], [0, 2]]))
-        self.assertTrue(np.all(dy[2, :] == [[1, 0], [0, 2]]))
+        self.assertTrue(np.all(dy[0, :] == [[1, 0], [0, 1]]))
+        self.assertTrue(np.all(dy[1, :] == [[1, 0], [0, 1]]))
+        self.assertTrue(np.all(dy[2, :] == [[1, 0], [0, 1]]))
 
         # Check residuals
         rx = y - np.array(values)
@@ -375,9 +375,9 @@ class TestErrorMeasures(unittest.TestCase):
         # Residuals are: [[0, 0], [-1, -3], [-2, -6]]
         # Derivatives are: [[1, 0], [0, 2]]
         # dex1 is: 2 * (0 - 1 - 2) * 1 = 2 * -3 * 1 = -6
-        # dex2 is: 2 * (0 - 3 - 6) * 2 = 2 * -9 * 2 = -36
+        # dex2 is: 2 * (0 - 3 - 6) * 2 = 2 * -9 * 1 = -18
         self.assertEqual(dex[0], -6)
-        self.assertEqual(dex[1], -36)
+        self.assertEqual(dex[1], -18)
 
     def test_sum_of_squares_error_weighted(self):
         """ Tests :class:`pints.MeanSquaredError` with weighted outputs. """
@@ -408,15 +408,15 @@ class TestErrorMeasures(unittest.TestCase):
         x = [1, 2]
 
         # Model outputs are 3 times [1, 4]
-        # Model derivatives are 3 times [[1, 0], [0, 2]]
+        # Model derivatives are 3 times [[1, 0], [0, 1]]
         y, dy = p.evaluateS1(x)
         self.assertTrue(np.all(y == p.evaluate(x)))
         self.assertTrue(np.all(y[0, :] == [1, 4]))
         self.assertTrue(np.all(y[1, :] == [1, 4]))
         self.assertTrue(np.all(y[2, :] == [1, 4]))
-        self.assertTrue(np.all(dy[0, :] == [[1, 0], [0, 2]]))
-        self.assertTrue(np.all(dy[1, :] == [[1, 0], [0, 2]]))
-        self.assertTrue(np.all(dy[2, :] == [[1, 0], [0, 2]]))
+        self.assertTrue(np.all(dy[0, :] == [[1, 0], [0, 1]]))
+        self.assertTrue(np.all(dy[1, :] == [[1, 0], [0, 1]]))
+        self.assertTrue(np.all(dy[2, :] == [[1, 0], [0, 1]]))
 
         # Check residuals
         rx = y - np.array(values)
@@ -437,15 +437,15 @@ class TestErrorMeasures(unittest.TestCase):
         self.assertEqual(dex.shape, (2, ))
 
         # Residuals are: [[0, 0], [-1, -3], [-2, -6]]
-        # Derivatives are: [[1, 0], [0, 2]]
+        # Derivatives are: [[1, 0], [0, 1]]
         # dex1 is: 2 * (0 - 1 - 2) * 1 * 1
         #        = 2 * -3 * 1 * 1
         #        = -6
-        # dex2 is: 2 * (0 - 3 - 6) * 2 * 2
-        #        = 2 * -9 * 2 * 2
-        #        = -72
+        # dex2 is: 2 * (0 - 3 - 6) * 2 * 1
+        #        = 2 * -9 * 2 * 1
+        #        = -36
         self.assertEqual(dex[0], -6)
-        self.assertEqual(dex[1], -72)
+        self.assertEqual(dex[1], -36)
 
     def test_sum_of_errors(self):
         """ Tests :class:`pints.SumOfErrors`. """

--- a/pints/tests/test_error_measures.py
+++ b/pints/tests/test_error_measures.py
@@ -154,7 +154,7 @@ class TestErrorMeasures(unittest.TestCase):
         x = [1, 2]
 
         # Model outputs are 3 times [1, 4]
-        # Model derivatives are 3 times [[1, 0], [0, 2]]
+        # Model derivatives are 3 times [[1, 0], [0, 1]]
         y, dy = p.evaluateS1(x)
         self.assertTrue(np.all(y == p.evaluate(x)))
         self.assertTrue(np.all(y[0, :] == [1, 4]))
@@ -183,7 +183,7 @@ class TestErrorMeasures(unittest.TestCase):
         self.assertEqual(dex.shape, (2, ))
 
         # Residuals are: [[0, 0], [-1, -3], [-2, -6]]
-        # Derivatives are: [[1, 0], [0, 2]]
+        # Derivatives are: [[1, 0], [0, 1]]
         # dex1 is: (2 / nt / no) * (0 - 1 - 2) * 1 = (1 / 3) * -3 * 1 = -1
         # dex2 is: (2 / nt / no) * (0 - 3 - 6) * 1 = (1 / 3) * -9 * 1 = -3
         self.assertEqual(dex[0], -1)
@@ -218,7 +218,7 @@ class TestErrorMeasures(unittest.TestCase):
         x = [1, 2]
 
         # Model outputs are 3 times [1, 4]
-        # Model derivatives are 3 times [[1, 0], [0, 2]]
+        # Model derivatives are 3 times [[1, 0], [0, 1]]
         y, dy = p.evaluateS1(x)
         self.assertTrue(np.all(y == p.evaluate(x)))
         self.assertTrue(np.all(y[0, :] == [1, 4]))
@@ -344,7 +344,7 @@ class TestErrorMeasures(unittest.TestCase):
         x = [1, 2]
 
         # Model outputs are 3 times [1,4]
-        # Model derivatives are 3 times [[1, 0], [0, 2]]
+        # Model derivatives are 3 times [[1, 0], [0, 1]]
         y, dy = p.evaluateS1(x)
         self.assertTrue(np.all(y == p.evaluate(x)))
         self.assertTrue(np.all(y[0, :] == [1, 4]))
@@ -373,7 +373,7 @@ class TestErrorMeasures(unittest.TestCase):
         self.assertEqual(dex.shape, (2, ))
 
         # Residuals are: [[0, 0], [-1, -3], [-2, -6]]
-        # Derivatives are: [[1, 0], [0, 2]]
+        # Derivatives are: [[1, 0], [0, 1]]
         # dex1 is: 2 * (0 - 1 - 2) * 1 = 2 * -3 * 1 = -6
         # dex2 is: 2 * (0 - 3 - 6) * 2 = 2 * -9 * 1 = -18
         self.assertEqual(dex[0], -6)

--- a/pints/tests/test_log_likelihoods.py
+++ b/pints/tests/test_log_likelihoods.py
@@ -451,6 +451,7 @@ class TestLogLikelihood(unittest.TestCase):
         self.assertTrue(np.all(3 * dy1 == dy))
 
     def test_ar1(self):
+        # single outputs
         model = pints.toy.ConstantModel(1)
         parameters = [0]
         times = np.asarray([1, 2, 3])
@@ -460,6 +461,16 @@ class TestLogLikelihood(unittest.TestCase):
         log_likelihood = pints.AR1LogLikelihood(problem)
         self.assertAlmostEqual(
             log_likelihood([0, 0.5, 5]), -19.706737485492436)
+
+        # multiple outputs
+        model = pints.toy.ConstantModel(4)
+        parameters = [0, 0, 0, 0]
+        times = np.arange(1, 4)
+        model.simulate(parameters, times)
+        values = np.asarray([[3.5, 7.6, 8.5, 3.4],
+                             [1.1, -10.3, 15.6, 5.5],
+                             [-10, -30.5, -5, 7.6]])
+        problem = pints.MultiOutputProblem(model, times, values)
 
     def test_arma11(self):
         model = pints.toy.ConstantModel(1)

--- a/pints/tests/test_log_likelihoods.py
+++ b/pints/tests/test_log_likelihoods.py
@@ -471,6 +471,7 @@ class TestLogLikelihood(unittest.TestCase):
                              [1.1, -10.3, 15.6, 5.5],
                              [-10, -30.5, -5, 7.6]])
         problem = pints.MultiOutputProblem(model, times, values)
+        log_likelihood = pints.AR1LogLikelihood(problem)
 
     def test_arma11(self):
         model = pints.toy.ConstantModel(1)

--- a/pints/tests/test_log_likelihoods.py
+++ b/pints/tests/test_log_likelihoods.py
@@ -465,7 +465,7 @@ class TestLogLikelihood(unittest.TestCase):
         # multiple outputs
         model = pints.toy.ConstantModel(4)
         parameters = [0, 0, 0, 0]
-        times = np.arange(1, 4)
+        times = np.arange(1, 5)
         model.simulate(parameters, times)
         values = np.asarray([[3.5, 7.6, 8.5, 3.4],
                              [1.1, -10.3, 15.6, 5.5],
@@ -496,6 +496,30 @@ class TestLogLikelihood(unittest.TestCase):
         log_likelihood = pints.ARMA11LogLikelihood(problem)
         self.assertAlmostEqual(
             log_likelihood([0, 0.9, -0.4, 1]), -171.53031588534171)
+
+        # multiple outputs
+        model = pints.toy.ConstantModel(4)
+        parameters = [0, 0, 0, 0]
+        times = np.arange(1, 5)
+        model.simulate(parameters, times)
+        values = np.asarray([[3.5, 7.6, 8.5, 3.4],
+                             [1.1, -10.3, 15.6, 5.5],
+                             [-10, -30.5, -5, 7.6],
+                             [-12, -10.1, -4, 2.3]])
+        problem = pints.MultiOutputProblem(model, times, values)
+        log_likelihood = pints.AR1LogLikelihood(problem)
+        # ARMA1Logpdf((3.5,1.1,-10, -12)|mean=0, rho=0.5, phi=0.34 sigma=1) +
+        # ARMA1Logpdf((7.6,-10.3,-30.5, -10.1)|
+        #             mean=0, rho=-0.25, phi=0.1, sigma=3) +
+        # ARMA1Logpdf((8.5,15.6,-5, -4)|mean=0, rho=0.9, phi=0.0, sigma=10) +
+        # ARMA1Logpdf((3.4,5.5,7.6, 2.3)|mean=0, rho=0.0, phi=0.9, sigma=2)
+        #      = -116.009 -74.94 -14.32 -8.88
+        self.assertAlmostEqual(
+            log_likelihood(parameters + [0.5, 0.34, 1.0,
+                                         -0.25, 0.1, 3.0,
+                                         0.9, 0.0, 10.0,
+                                         0.0, 0.9, 2.0]),
+            -214.17034137601107)
 
 
 if __name__ == '__main__':

--- a/pints/tests/test_log_likelihoods.py
+++ b/pints/tests/test_log_likelihoods.py
@@ -78,6 +78,31 @@ class TestLogLikelihood(unittest.TestCase):
         self.assertAlmostEqual(dy1[0] / dy3[0], 1)
         self.assertAlmostEqual(dy1[1] / dy3[1], 1)
 
+        # test values of log-likelihood and derivatives
+        model = pints.toy.ConstantModel(3)
+        times = [1, 2, 3, 4]
+        parameters = [0, 0, 0]
+        org_values = [[10.7, 3.5, 3.8],
+                      [1.1, 3.2, -1.4],
+                      [9.3, 0.0, 4.5],
+                      [1.2, -3, -10]]
+        problem = pints.MultiOutputProblem(model, times, org_values)
+        f2 = pints.GaussianKnownSigmaLogLikelihood(problem, [3.5, 1, 12])
+        log_likelihood = pints.ScaledLogLikelihood(f2)
+        # Test Gaussian_logpdf((10.7, 1.1, 9.3, 1.2)|mean=0, sigma=3.5) +
+        #      Gaussian_logpdf((3.5, 3.2, 0.0, -3)|mean=0, sigma=1) +
+        #      Gaussian_logpdf((3.8, -1.4, 4.5, -10)|mean=0, sigma=12)
+        #      = -50.5088...
+        self.assertAlmostEqual(
+            log_likelihood(parameters),
+            -50.508848609684783 / 12.0
+        )
+        l, dl = log_likelihood.evaluateS1(parameters)
+        self.assertAlmostEqual(l, -50.508848609684783 / 12.0)
+        self.assertAlmostEqual(dl[0], 1.820408163265306 / 12.0)
+        self.assertAlmostEqual(dl[1], 3.7000000000000002 / 12.0)
+        self.assertAlmostEqual(dl[2], -0.021527777777777774 / 12.0)
+
     def test_gaussian_log_likelihoods_single_output(self):
         """
         Single-output test for known/unknown noise log-likelihood methods

--- a/pints/tests/test_log_likelihoods.py
+++ b/pints/tests/test_log_likelihoods.py
@@ -469,9 +469,22 @@ class TestLogLikelihood(unittest.TestCase):
         model.simulate(parameters, times)
         values = np.asarray([[3.5, 7.6, 8.5, 3.4],
                              [1.1, -10.3, 15.6, 5.5],
-                             [-10, -30.5, -5, 7.6]])
+                             [-10, -30.5, -5, 7.6],
+                             [-12, -10.1, -4, 2.3]])
         problem = pints.MultiOutputProblem(model, times, values)
         log_likelihood = pints.AR1LogLikelihood(problem)
+        # Test AR1Logpdf((3.5,1.1,-10, -12)|mean=0, rho=0.5, sigma=1) +
+        #      AR1Logpdf((7.6,-10.3,-30.5, -10.1)|mean=0, rho=-0.25, sigma=3) +
+        #      AR1Logpdf((8.5,15.6,-5, -4)|mean=0, rho=0.9, sigma=10) +
+        #      AR1Logpdf((3.4,5.5,7.6, 2.3)|mean=0, rho=0.0, sigma=2)
+        #      = -109.4752924909364 -75.32717801724532
+        #
+        self.assertAlmostEqual(
+            log_likelihood(parameters + [0.5, 1.0,
+                                         -0.25, 3.0,
+                                         0.9, 10.0,
+                                         0.0, 1.0]),
+            -47.83720347766945)
 
     def test_arma11(self):
         model = pints.toy.ConstantModel(1)

--- a/pints/tests/test_log_likelihoods.py
+++ b/pints/tests/test_log_likelihoods.py
@@ -477,14 +477,14 @@ class TestLogLikelihood(unittest.TestCase):
         #      AR1Logpdf((7.6,-10.3,-30.5, -10.1)|mean=0, rho=-0.25, sigma=3) +
         #      AR1Logpdf((8.5,15.6,-5, -4)|mean=0, rho=0.9, sigma=10) +
         #      AR1Logpdf((3.4,5.5,7.6, 2.3)|mean=0, rho=0.0, sigma=2)
-        #      = -109.4752924909364 -75.32717801724532
-        #
+        #      = -109.4752924909364 -93.58199 - 18.3833..
+        #        -16.4988
         self.assertAlmostEqual(
             log_likelihood(parameters + [0.5, 1.0,
                                          -0.25, 3.0,
                                          0.9, 10.0,
-                                         0.0, 1.0]),
-            -47.83720347766945)
+                                         0.0, 2.0]),
+            -237.93936126949615)
 
     def test_arma11(self):
         model = pints.toy.ConstantModel(1)

--- a/pints/tests/test_toy_constant_model.py
+++ b/pints/tests/test_toy_constant_model.py
@@ -174,11 +174,11 @@ class TestConstantModel(unittest.TestCase):
         self.assertEqual(dy.shape, (3, 2, 2))
         dmx = np.array(
             [[[1, 0],   # dx1/dp1 = 1, dx1/dp2 = 0
-              [0, 2]],  # dx2/dp2 = 0, dx2/dp2 = 2
+              [0, 1]],  # dx2/dp2 = 0, dx2/dp2 = 1
              [[1, 0],
-              [0, 2]],
+              [0, 1]],
              [[1, 0],
-              [0, 2]]]
+              [0, 1]]]
         )
         self.assertTrue(np.all(dy == dmx))
 

--- a/pints/toy/_constant_model.py
+++ b/pints/toy/_constant_model.py
@@ -30,7 +30,7 @@ class ConstantModel(pints.ForwardModelS1):
     .. math::
 
         \\frac{\partial{f_i(t)}}{dp_j} =
-            \\begin{cases} i, i = j\\\\0, i \\neq j \end{cases}
+            \\begin{cases} 1, i = j\\\\0, i \\neq j \end{cases}
 
     Arguments:
 
@@ -107,5 +107,5 @@ class ConstantModel(pints.ForwardModelS1):
             # i.e.
             #  [[1, 0],
             #   [0, 1]]
-            dy = np.tile(np.diag(np.ones(len(self._r))), (len(times), 1, 1))
+            dy = np.tile(np.diag(np.ones(self._n)), (len(times), 1, 1))
         return (y, dy)

--- a/pints/toy/_constant_model.py
+++ b/pints/toy/_constant_model.py
@@ -106,8 +106,6 @@ class ConstantModel(pints.ForwardModelS1):
             #   [df2/dp1, df2/dp2]]
             # i.e.
             #  [[1, 0],
-            #   [0, 2]]
-            # i.e. np.diag(self._r)
-            dy = np.tile(np.diag(self._r), (len(times), 1, 1))
+            #   [0, 1]]
+            dy = np.tile(np.diag(np.ones(len(self._r))), (len(times), 1, 1))
         return (y, dy)
-


### PR DESCRIPTION
In this checking of the tests, I (somewhat disconcertingly) found about a dozen errors that would have been picked up if we were doing value-based tests of log-likelihoods. The errors were on the following:

- AR1 values for multiple output problems
- ARMA11 values for multiple output problems
- Gaussian log likelihood values and derivatives for multiple output problems. Given that this is our workhorse distribution for many problems this was particularly concerning
- The ConstantModel which we use for testing previously had incorrect derivatives; these should always be 1 since f = theta -> df / dtheta = 1.

Covers #719 