### PR TITLE
Irregular boundary handling in CMA-ES

### DIFF
--- a/pints/_error_measures.py
+++ b/pints/_error_measures.py
@@ -138,9 +138,9 @@ class SumOfErrors(ErrorMeasure):
         super(SumOfErrors, self).__init__()
 
         # Check input arguments
-        if len(error_measures) < 2:
+        if len(error_measures) < 1:
             raise ValueError(
-                'SumOfErrors requires at least 2 error measures.')
+                'SumOfErrors requires at least 1 error measure.')
         if weights is None:
             weights = [1] * len(error_measures)
         elif len(error_measures) != len(weights):

--- a/pints/_optimisers/__init__.py
+++ b/pints/_optimisers/__init__.py
@@ -434,7 +434,7 @@ class OptimisationController(object):
                     print('Maximising LogPDF')
 
                 # Show method
-                print('using ' + str(self._optimiser.name()))
+                print('Using ' + str(self._optimiser.name()))
 
                 # Show parallelisation
                 if self._parallel:

--- a/pints/_optimisers/_cmaes.py
+++ b/pints/_optimisers/_cmaes.py
@@ -61,7 +61,7 @@ class CMAES(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
-            if len(self._user_xs) == 0:     # pragma: no-cover
+            if len(self._user_xs) == 0:     # pragma: no cover
                 self._logger.warning(
                     'All points requested by CMA-ES are outside the'
                     ' boundaries.')

--- a/pints/_optimisers/_cmaes.py
+++ b/pints/_optimisers/_cmaes.py
@@ -16,7 +16,7 @@ import pints
 class CMAES(pints.PopulationBasedOptimiser):
     """
     Finds the best parameters using the CMA-ES method described in [1, 2] and
-    implemented in the `cma` module.
+    implemented in the ``cma`` module.
 
     CMA-ES stands for Covariance Matrix Adaptation Evolution Strategy, and is
     designed for non-linear derivative-free optimization problems.
@@ -183,9 +183,10 @@ class CMAES(pints.PopulationBasedOptimiser):
 
         # Manual boundaries? Then reconstruct full fx vector
         if self._manual_boundaries and len(fx) < self._population_size:
-            # Note: CMA-ES uses `nan` to mean "could not calculate this point".
+            # Note: CMA-ES uses ``nan`` to mean "could not calculate this
+            # point".
             user_fx = fx
-            fx = np.ones((self._population_size, )) * float('nan')
+            fx = np.ones((self._population_size, )) * float('inf')
             fx[self._user_ids] = user_fx
 
         # Tell CMA-ES

--- a/pints/_optimisers/_cmaes.py
+++ b/pints/_optimisers/_cmaes.py
@@ -188,9 +188,11 @@ class CMAES(pints.PopulationBasedOptimiser):
         # Manual boundaries? Then reconstruct full fx vector
         if self._manual_boundaries and len(fx) < self._population_size:
             # Note: CMA-ES uses ``nan`` to mean "could not calculate this
-            # point".
+            # point". But for some reason this doesn't work well, causes a lot
+            # of points to go out of bounds for some reason. Works much better
+            # when just using ``inf``...
             user_fx = fx
-            fx = np.ones((self._population_size, )) * float('inf')
+            fx = np.ones((self._population_size, )) * np.inf
             fx[self._user_ids] = user_fx
 
         # Tell CMA-ES

--- a/pints/_optimisers/_cmaes.py
+++ b/pints/_optimisers/_cmaes.py
@@ -61,6 +61,10 @@ class CMAES(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
+            if len(self._user_xs) == 0:     # pragma: no-cover
+                self._logger.warning(
+                    'All points requested by CMA-ES are outside the'
+                    ' boundaries.')
 
         # Set as read-only and return
         self._user_xs.setflags(write=False)

--- a/pints/_optimisers/_pso.py
+++ b/pints/_optimisers/_pso.py
@@ -167,7 +167,7 @@ class PSO(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
-            if len(self._user_xs) == 0:     # pragma: no-cover
+            if len(self._user_xs) == 0:     # pragma: no cover
                 self._logger.warning(
                     'All initial PSO particles are outside the boundaries.')
         else:
@@ -285,7 +285,7 @@ class PSO(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
-            if len(self._user_xs) == 0:     # pragma: no-cover
+            if len(self._user_xs) == 0:     # pragma: no cover
                 self._logger.warning(
                     'All PSO particles are outside the boundaries.')
         else:

--- a/pints/_optimisers/_pso.py
+++ b/pints/_optimisers/_pso.py
@@ -10,8 +10,9 @@
 #
 from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
-import pints
+import logging
 import numpy as np
+import pints
 
 
 class PSO(pints.PopulationBasedOptimiser):
@@ -84,6 +85,9 @@ class PSO(pints.PopulationBasedOptimiser):
 
         # Set default settings
         self.set_local_global_balance()
+
+        # Python logger
+        self._logger = logging.getLogger(__name__)
 
     def ask(self):
         """ See :meth:`Optimiser.ask()`. """
@@ -163,6 +167,9 @@ class PSO(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
+            if len(self._user_xs) == 0:     # pragma: no-cover
+                self._logger.warning(
+                    'All initial PSO particles are outside the boundaries.')
         else:
             self._user_xs = np.array(self._xs, copy=True)
 
@@ -278,6 +285,9 @@ class PSO(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
+            if len(self._user_xs) == 0:     # pragma: no-cover
+                self._logger.warning(
+                    'All PSO particles are outside the boundaries.')
         else:
             self._user_xs = np.array(self._xs, copy=True)
 

--- a/pints/_optimisers/_snes.py
+++ b/pints/_optimisers/_snes.py
@@ -10,8 +10,9 @@
 #
 from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
-import pints
+import logging
 import numpy as np
+import pints
 
 
 class SNES(pints.PopulationBasedOptimiser):
@@ -46,6 +47,9 @@ class SNES(pints.PopulationBasedOptimiser):
         self._xbest = pints.vector(x0)
         self._fbest = float('inf')
 
+        # Python logger
+        self._logger = logging.getLogger(__name__)
+
     def ask(self):
         """ See :meth:`Optimiser.ask()`. """
         # Initialise on first call
@@ -69,6 +73,9 @@ class SNES(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
+            if len(self._user_xs) == 0:     # pragma: no-cover
+                self._logger.warning(
+                    'All points requested by SNES are outside the boundaries.')
         else:
             self._user_xs = self._xs
 

--- a/pints/_optimisers/_snes.py
+++ b/pints/_optimisers/_snes.py
@@ -73,7 +73,7 @@ class SNES(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
-            if len(self._user_xs) == 0:     # pragma: no-cover
+            if len(self._user_xs) == 0:     # pragma: no cover
                 self._logger.warning(
                     'All points requested by SNES are outside the boundaries.')
         else:

--- a/pints/_optimisers/_xnes.py
+++ b/pints/_optimisers/_xnes.py
@@ -72,7 +72,7 @@ class XNES(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
-            if len(self._user_xs) == 0:     # pragma: no-cover
+            if len(self._user_xs) == 0:     # pragma: no cover
                 self._logger.warning(
                     'All points requested by XNES are outside the boundaries.')
         else:

--- a/pints/_optimisers/_xnes.py
+++ b/pints/_optimisers/_xnes.py
@@ -10,8 +10,9 @@
 #
 from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
-import pints
+import logging
 import numpy as np
+import pints
 import scipy
 import scipy.linalg
 
@@ -44,6 +45,9 @@ class XNES(pints.PopulationBasedOptimiser):
         self._xbest = pints.vector(x0)
         self._fbest = float('inf')
 
+        # Python logger
+        self._logger = logging.getLogger(__name__)
+
     def ask(self):
         """ See :meth:`Optimiser.ask()`. """
         # Initialise on first call
@@ -68,6 +72,9 @@ class XNES(pints.PopulationBasedOptimiser):
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
+            if len(self._user_xs) == 0:     # pragma: no-cover
+                self._logger.warning(
+                    'All points requested by XNES are outside the boundaries.')
         else:
             self._user_xs = self._xs
 

--- a/pints/tests/test_error_measures.py
+++ b/pints/tests/test_error_measures.py
@@ -502,8 +502,8 @@ class TestErrorMeasures(unittest.TestCase):
             e = pints.SumOfErrors([e4, e5, e1], [2.1, 3.4, 6.5])
             self.assertTrue(np.isnan(e(x)))
 
-        # Wrong number of arguments
-        self.assertRaises(ValueError, pints.SumOfErrors, [e1], [1])
+        # Wrong number of ErrorMeasures
+        self.assertRaises(ValueError, pints.SumOfErrors, [], [])
 
         # Wrong argument types
         self.assertRaises(

--- a/pints/tests/test_opt_optimisation_controller.py
+++ b/pints/tests/test_opt_optimisation_controller.py
@@ -76,7 +76,7 @@ class TestOptimisationController(unittest.TestCase):
 
             log_should_be = (
                 'Maximising LogPDF\n'
-                'using Exponential Natural Evolution Strategy (xNES)\n'
+                'Using Exponential Natural Evolution Strategy (xNES)\n'
                 'Running in sequential mode.\n'
                 'Population size: 6\n'
                 'Iter. Eval. Best      Time m:s\n'

--- a/pints/tests/test_opt_pso.py
+++ b/pints/tests/test_opt_pso.py
@@ -130,7 +130,7 @@ class TestPSO(unittest.TestCase):
 
         self.assertEqual(len(lines), 11)
         self.assertEqual(lines[0], 'Maximising LogPDF')
-        self.assertEqual(lines[1], 'using Particle Swarm Optimisation (PSO)')
+        self.assertEqual(lines[1], 'Using Particle Swarm Optimisation (PSO)')
         self.assertEqual(
             lines[2], 'Running in parallel with 2 worker processes.')
         self.assertEqual(lines[3], 'Population size: 6')


### PR DESCRIPTION
It seems the way we were doing irregular boundaries in CMA-ES, using `nan` to tell cma-es points couldn't be evaluated, makes it much less robust than simply returning `inf`.