### PR TITLE
i844

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ __pycache__/
 # Studies have their own repo now
 studies
 
-# venvs
+# Virtual environments
 venv*

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,11 @@ __pycache__/
 # vscode
 .vscode
 
+# pycharm
+.idea
+
 # Studies have their own repo now
 studies
+
+# venvs
+venv*

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
   - if [[ $PINTS_UNIT == true ]]; then python run-tests.py --unit; fi;
   - if [[ $PINTS_DOCS == true ]]; then python run-tests.py --doctest; fi;
   - if [[ $PINTS_STYLE == true ]]; then python -m flake8; fi;
-  - if [[ $PINTS_COVER == true ]]; then coverage run run-tests.py --nosub; fi;
+  - if [[ $PINTS_COVER == true ]]; then coverage run run-tests.py --unit; fi;
   - if [[ $TRAVIS_EVENT_TYPE == 'cron' ]]; then travis_wait 120 python run-tests.py --books; fi;
 
 after_success:

--- a/run-tests.py
+++ b/run-tests.py
@@ -19,7 +19,7 @@ import subprocess
 
 def run_unit_tests():
     """
-    Runs unit tests using same interpreter and environment as for this script.
+    Runs unit tests (without subprocesses).
     """
     tests = os.path.join('pints', 'tests')
     suite = unittest.defaultTestLoader.discover(tests, pattern='test*.py')
@@ -77,7 +77,8 @@ def run_doctests():
 
 def doctest_sphinx():
     """
-    Checks that sphinx-build can be invoked without producing errors
+    Runs sphinx-build in a subprocess, checking that it can be invoked without
+    producing errors.
     """
     print('Checking if docs can be built.')
     p = subprocess.Popen([
@@ -420,7 +421,7 @@ def scan_for_notebooks(
 
 def test_notebook(path):
     """
-    Tests a single notebook, exists if it doesn't finish.
+    Tests a notebook in a subprocess, exists if it doesn't finish.
     """
     import nbconvert
     import pints

--- a/run-tests.py
+++ b/run-tests.py
@@ -17,39 +17,13 @@ import unittest
 import subprocess
 
 
-def run_unit_tests(executable=None):
+def run_unit_tests():
     """
-    Runs unit tests, exits if they don't finish.
-
-    If an ``executable`` is given, tests are run in subprocesses using the
-    given executable (e.g. ``python2`` or ``python3``).
+    Runs unit tests using same interpreter and environment as for this script.
     """
     tests = os.path.join('pints', 'tests')
-    if executable is None:
-        suite = unittest.defaultTestLoader.discover(tests, pattern='test*.py')
-        unittest.TextTestRunner(verbosity=2).run(suite)
-    else:
-        print('Running unit tests with executable `' + executable + '`')
-        cmd = [executable] + [
-            '-m',
-            'unittest',
-            'discover',
-            '-v',
-            tests,
-        ]
-        p = subprocess.Popen(cmd)
-        try:
-            ret = p.wait()
-        except KeyboardInterrupt:
-            try:
-                p.terminate()
-            except OSError:
-                pass
-            p.wait()
-            print('')
-            sys.exit(1)
-        if ret != 0:
-            sys.exit(ret)
+    suite = unittest.defaultTestLoader.discover(tests, pattern='test*.py')
+    unittest.TextTestRunner(verbosity=2).run(suite)
 
 
 def run_flake8():
@@ -58,7 +32,9 @@ def run_flake8():
     """
     print('Running flake8 ... ')
     sys.stdout.flush()
-    p = subprocess.Popen(['flake8'], stderr=subprocess.PIPE)
+    p = subprocess.Popen(
+        [sys.executable, '-m', 'flake8'], stderr=subprocess.PIPE
+    )
     try:
         ret = p.wait()
     except KeyboardInterrupt:
@@ -442,7 +418,7 @@ def scan_for_notebooks(
     return ok
 
 
-def test_notebook(path, executable='python'):
+def test_notebook(path):
     """
     Tests a single notebook, exists if it doesn't finish.
     """
@@ -460,14 +436,15 @@ def test_notebook(path, executable='python'):
     code = '\n'.join([x for x in code.splitlines() if x[:9] != '# coding'])
 
     # Tell matplotlib not to produce any figures
-    env = dict(os.environ)
+    env = os.environ.copy()
     env['MPLBACKEND'] = 'Template'
 
     # Run in subprocess
-    cmd = [executable] + ['-c', code]
+    cmd = [sys.executable, '-c', code]
     try:
         p = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        )
         stdout, stderr = p.communicate()
         # TODO: Use p.communicate(timeout=3600) if Python3 only
         if p.returncode != 0:
@@ -532,21 +509,6 @@ if __name__ == '__main__':
         action='store_true',
         help='Run all unit tests using the `python` interpreter.',
     )
-    parser.add_argument(
-        '--unit2',
-        action='store_true',
-        help='Run all unit tests using the `python2` interpreter.',
-    )
-    parser.add_argument(
-        '--unit3',
-        action='store_true',
-        help='Run all unit tests using the `python3` interpreter.',
-    )
-    parser.add_argument(
-        '--nosub',
-        action='store_true',
-        help='Run all unit tests without starting a subprocess.',
-    )
     # Notebook tests
     parser.add_argument(
         '--books',
@@ -585,15 +547,6 @@ if __name__ == '__main__':
     # Unit tests
     if args.unit:
         has_run = True
-        run_unit_tests('python')
-    if args.unit2:
-        has_run = True
-        run_unit_tests('python2')
-    if args.unit3:
-        has_run = True
-        run_unit_tests('python3')
-    if args.nosub:
-        has_run = True
         run_unit_tests()
     # Doctests
     if args.doctest:
@@ -613,7 +566,7 @@ if __name__ == '__main__':
     if args.quick:
         has_run = True
         run_flake8()
-        run_unit_tests('python')
+        run_unit_tests()
         run_doctests()
     # Help
     if not has_run:


### PR DESCRIPTION
See #844 : don't run unit tests in subprocess.  Simplifies `run_tests` script and removes the possibility of spawning processes running with a different python environment.