### PR TITLE
Add "results object" methods to OptimisationController

### DIFF
--- a/pints/_optimisers/__init__.py
+++ b/pints/_optimisers/__init__.py
@@ -352,6 +352,7 @@ class OptimisationController(object):
         # Post-run statistics
         self._evaluations = None
         self._iterations = None
+        self._time = None
 
     def evaluations(self):
         """
@@ -578,18 +579,20 @@ class OptimisationController(object):
                 print(pints.strfloat(p))
             print('-' * 40)
             raise
+        time_taken = timer.time()
 
         # Log final values and show halt message
         if logging:
             logger.log(iteration, evaluations, fbest_user)
             self._optimiser._log_write(logger)
-            logger.log(timer.time())
+            logger.log(time_taken)
             if self._log_to_screen:
                 print(halt_message)
 
         # Save post-run statistics
         self._evaluations = evaluations
         self._iterations = iteration
+        self._time = time_taken
 
         # Return best position and score
         return self._optimiser.xbest(), fbest_user
@@ -715,6 +718,13 @@ class OptimisationController(object):
         stopping criterion is set. See :meth:`set_threshold()`.
         """
         return self._threshold
+
+    def time(self):
+        """
+        Returns the time needed for the last run, in seconds, or ``None`` if
+        the controller hasn't ran yet.
+        """
+        return self._time
 
 
 class Optimisation(OptimisationController):

--- a/pints/_optimisers/__init__.py
+++ b/pints/_optimisers/__init__.py
@@ -587,6 +587,10 @@ class OptimisationController(object):
             if self._log_to_screen:
                 print(halt_message)
 
+        # Save post-run statistics
+        self._evaluations = evaluations
+        self._iterations = iteration
+
         # Return best position and score
         return self._optimiser.xbest(), fbest_user
 

--- a/pints/_optimisers/__init__.py
+++ b/pints/_optimisers/__init__.py
@@ -349,6 +349,24 @@ class OptimisationController(object):
         # Threshold value
         self._threshold = None
 
+        # Post-run statistics
+        self._evaluations = None
+        self._iterations = None
+
+    def evaluations(self):
+        """
+        Returns the number of evaluations performed during the last run, or
+        ``None`` if the controller hasn't ran yet.
+        """
+        return self._evaluations
+
+    def iterations(self):
+        """
+        Returns the number of iterations performed during the last run, or
+        ``None`` if the controller hasn't ran yet.
+        """
+        return self._iterations
+
     def max_iterations(self):
         """
         Returns the maximum iterations if this stopping criterion is set, or

--- a/pints/tests/test_opt_optimisation_controller.py
+++ b/pints/tests/test_opt_optimisation_controller.py
@@ -253,6 +253,8 @@ class TestOptimisationController(unittest.TestCase):
 
         self.assertEqual(opt.iterations(), 75)
         self.assertEqual(opt.evaluations(), 450)
+        t = opt.time()
+        self.assertTrue(0 < t < 5)
 
 
 if __name__ == '__main__':

--- a/pints/tests/test_opt_optimisation_controller.py
+++ b/pints/tests/test_opt_optimisation_controller.py
@@ -238,6 +238,22 @@ class TestOptimisationController(unittest.TestCase):
         opt = pints.Optimisation(r, x, boundaries=b, method=method)
         self.assertIsInstance(opt, pints.OptimisationController)
 
+    def test_post_run_statistics(self):
+        """ Test the methods to return statistics, post-run. """
+        r = pints.toy.TwistedGaussianLogPDF(2, 0.01)
+        x = np.array([0, 1.01])
+        b = pints.RectangularBoundaries([-0.01, 0.95], [0.01, 1.05])
+        s = 0.01
+        opt = pints.OptimisationController(r, x, s, b, method)
+        opt.set_log_to_screen(False)
+        opt.set_max_unchanged_iterations(50, 1e-11)
+
+        np.random.seed(123)
+        opt.run()
+
+        self.assertEqual(opt.iterations(), 75)
+        self.assertEqual(opt.evaluations(), 450)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
See #861 

Currently have `iterations()`, `evaluations()`, and `time()`. 

Could consider adding more e.g. `fbest()`, `xbest()` (or similar)
Could also consider adding similar methods to MCMCController and others (but in a separate PR, ideally)