### PR TITLE
Bug in loglikelihoods test.

### DIFF
--- a/pints/tests/test_log_likelihoods.py
+++ b/pints/tests/test_log_likelihoods.py
@@ -618,7 +618,7 @@ class TestLogLikelihood(unittest.TestCase):
 
         # Note: y and ll(x) differ a bit, because the solver acts slightly
         # different when evaluating with and without sensitivities!
-        self.assertTrue(np.abs(y - ll(x) < 1e-6))
+        self.assertTrue(np.abs(y - ll(x)) < 1e-6)
 
         self.assertEqual(dy.shape, (nx, ))
         y1, dy1 = l1.evaluateS1(x)

--- a/pints/tests/test_log_likelihoods.py
+++ b/pints/tests/test_log_likelihoods.py
@@ -70,7 +70,7 @@ class TestLogLikelihood(unittest.TestCase):
         # Test multi-output derivatives
         y1, dy1 = unscaled.evaluateS1(p)
         y2, dy2 = scaled.evaluateS1(p)
-        self.assertAlmostEqual(y1, unscaled(p))
+        self.assertAlmostEqual(y1, unscaled(p), places=6)
         self.assertEqual(dy1.shape, (3, ))
         self.assertAlmostEqual(y2, scaled(p))
         self.assertEqual(dy2.shape, (3, ))
@@ -618,7 +618,7 @@ class TestLogLikelihood(unittest.TestCase):
 
         # Note: y and ll(x) differ a bit, because the solver acts slightly
         # different when evaluating with and without sensitivities!
-        self.assertTrue(np.abs(y - ll(x)) < 1e-6)
+        self.assertAlmostEqual(y, ll(x), places=3)
 
         self.assertEqual(dy.shape, (nx, ))
         y1, dy1 = l1.evaluateS1(x)

--- a/pints/toy/_fitzhugh_nagumo_model.py
+++ b/pints/toy/_fitzhugh_nagumo_model.py
@@ -176,4 +176,3 @@ class FitzhughNagumoModel(pints.ForwardModelS1, ToyModel):
     def suggested_times(self):
         """ See :meth:`pints.toy.ToyModel.suggested_times()`. """
         return np.linspace(0, 20, 200)
-


### PR DESCRIPTION
@ben18785 could you have a look at this? I spotted a bug:

    self.assertTrue(np.abs(y - ll(x) < 1e-6))

this asserts that np.abs(z) is true, where z is the expression `y - ll(x) < 1e-6`
As it turns out, `y - ll(x)` is negative, so that z = True, and abs(z) = 1...

Corrected the bracket mistake, but now the tolerance is no longer met

