### PR TITLE
Repeated calls to DiffEv ask() increased iteration count.

### DIFF
--- a/pints/_mcmc/_differential_evolution.py
+++ b/pints/_mcmc/_differential_evolution.py
@@ -96,13 +96,14 @@ class DifferentialEvolutionMCMC(pints.MultiChainMCMC):
         if not self._running:
             self._initialise()
 
-        # set gamma to 1
-        if self._iter_count % self._gamma_switch_rate == 0:
-            self._gamma = 1
-        self._iter_count += 1
-
         # Propose new points
         if self._proposed is None:
+
+            # set gamma to 1
+            if self._iter_count % self._gamma_switch_rate == 0:
+                self._gamma = 1
+            self._iter_count += 1
+
             self._proposed = np.zeros(self._current.shape)
             for j in range(self._chains):
                 if self._gaussian_error:


### PR DESCRIPTION
We're not explicit about this in the docs, but MCMC methods have two options for ask():

1. Only allow one call (we do this for hamiltonian methods) between tells
2. Return the same proposal if ask() is called repeatedly

DiffEv followed pattern number 2, but updated an iteration count with each call