### PR TITLE
i1074 gh actions

### DIFF
--- a/.github/workflows/copyright-test.yml
+++ b/.github/workflows/copyright-test.yml
@@ -1,4 +1,4 @@
-name: Unit tests on multiple operating systems
+name: Copyright
 
 on:
   push:
@@ -12,11 +12,8 @@ on:
 jobs:
 
   build-and-test:
-    name: unit test (OS coverage)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-16.04, macos-latest, windows-latest]
+    name: copyright
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
@@ -33,6 +30,6 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .
 
-      - name: run unit tests
+      - name: run copyright test
         run: |
-          python run-tests.py --unit
+          python run-tests.py --copyright

--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -1,4 +1,4 @@
-name: Unit tests on multiple operating systems
+name: Coverage
 
 on:
   push:
@@ -12,11 +12,8 @@ on:
 jobs:
 
   build-and-test:
-    name: unit test (OS coverage)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-16.04, macos-latest, windows-latest]
+    name: coverage
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
@@ -32,7 +29,13 @@ jobs:
           python --version
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .
+          python -m pip install coverage codecov
 
-      - name: run unit tests
+      - name: run coverage
         run: |
-          python run-tests.py --unit
+          coverage run run-tests.py --unit
+
+      - name: codecov
+        if: success()
+        run: |
+          codecov

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -1,4 +1,4 @@
-name: Unit tests on multiple operating systems
+name: Doctest
 
 on:
   push:
@@ -12,11 +12,8 @@ on:
 jobs:
 
   build-and-test:
-    name: unit test (OS coverage)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-16.04, macos-latest, windows-latest]
+    name: doctest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
@@ -32,7 +29,8 @@ jobs:
           python --version
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .
+          python -m pip install .[docs]
 
-      - name: run unit tests
+      - name: run doctest
         run: |
-          python run-tests.py --unit
+          python run-tests.py --doctest

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -1,22 +1,15 @@
-name: Unit tests on multiple operating systems
+name: Notebooks
 
 on:
-  push:
-    branches:
-      - master
-      - i1074-gh-actions
-  pull_request:
-    branches:
-      - '**'
+  schedule:
+    # 1am every Friday morning
+    - cron:  '0 1 * * 5'
 
 jobs:
 
   build-and-test:
-    name: unit test (OS coverage)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-16.04, macos-latest, windows-latest]
+    name: notebooks
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
@@ -32,7 +25,8 @@ jobs:
           python --version
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .
+          python -m pip install .[dev]
 
-      - name: run unit tests
+      - name: run jupyter notebooks
         run: |
-          python run-tests.py --unit
+          python run-tests.py --allbooks

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -1,4 +1,4 @@
-name: Unit tests on multiple operating systems
+name: Style tests (flake8)
 
 on:
   push:
@@ -12,11 +12,8 @@ on:
 jobs:
 
   build-and-test:
-    name: unit test (OS coverage)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-16.04, macos-latest, windows-latest]
+    name: style test
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
@@ -32,7 +29,8 @@ jobs:
           python --version
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .
+          python -m pip install .[dev]
 
-      - name: run unit tests
+      - name: run style tests
         run: |
-          python run-tests.py --unit
+          python -m flake8

--- a/.github/workflows/unit-test-os-coverage.yml
+++ b/.github/workflows/unit-test-os-coverage.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Unit tests on multiple operating systems
 
 on:
   push:
@@ -12,20 +12,19 @@ on:
 jobs:
 
   build-and-test:
-    name: Unit tests on a number of OS and Python versions
+    name: Unit test (OS coverage)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        os: [ubuntu-16.04, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
           architecture: x64
 
       - name: install python bindings

--- a/.github/workflows/unit-test-python-coverage.yml
+++ b/.github/workflows/unit-test-python-coverage.yml
@@ -1,0 +1,38 @@
+name: Unit tests on multiple python versions
+
+on:
+  push:
+    branches:
+      - master
+      - i1074-gh-actions
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+
+  build-and-test:
+    name: Unit test (python coverage)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+
+      - name: install python bindings
+        run: |
+          python --version
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install .
+
+      - name: python unit tests
+        run: |
+          python run-tests.py --unit

--- a/.github/workflows/unit-test-python-coverage.yml
+++ b/.github/workflows/unit-test-python-coverage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   build-and-test:
-    name: Unit test (python coverage)
+    name: unit test (python coverage)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,12 +27,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
-      - name: install python bindings
+      - name: install pints
         run: |
           python --version
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .
 
-      - name: python unit tests
+      - name: run unit tests
         run: |
           python run-tests.py --unit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,39 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - master
+      - i1074-gh-actions
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+
+  build-and-test:
+    name: Unit tests on a number of OS and Python versions
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-latest, macos-latest, windows-latest]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+
+      - name: install python bindings
+        run: |
+          python --version
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install .
+
+      - name: python unit tests
+        run: |
+          python run-tests.py --unit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,4 +37,3 @@ jobs:
       - name: python unit tests
         run: |
           python run-tests.py --unit
-

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,3 +37,4 @@ jobs:
       - name: python unit tests
         run: |
           python run-tests.py --unit
+


### PR DESCRIPTION
See #1074 and #848 

This PR adds GitHub actions scripts for:

- copyright
- coverage
- doctest
- style
- unit tests (Python 3.8 on [ubuntu-16.04, macos-latest, windows-latest])
- unit tests (ubuntu-18.04 on Python [2.7, 3.5, 3.6, 3.7, 3.8])

These are set to run on pushes to the current branch and master, and all pull requests.

In addition there is a GitHub actions script for:

- notebooks

which is set to run on a cron job at 1am every Friday morning.

I would suggest merging these changes now.  They are all additions so will run as well as Travis, AppVeyor etc.  Once it's merged and working on master, we can tidy up the existing integrations, change over the status badges, etc.