### PR TITLE
676 ar arma docs

### DIFF
--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -109,7 +109,7 @@ class ARMA11LogLikelihood(pints.ProblemLogLikelihood):
     calculates a likelihood conditioned on initial values. This topic is
     discussed further in [2]_ , chapter 5.6. Thus, for a time series defined at
     points :math:`i=1,...,N`, summation begins at :math:`i=3`, and the
-    conditional likelihood is
+    conditional log-likelihood is
 
     .. math::
         L(\theta, \sigma, \rho, \phi|\boldsymbol{x}) =

--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -14,26 +14,41 @@ import scipy.special
 
 class AR1LogLikelihood(pints.ProblemLogLikelihood):
     r"""
-    Calculates a log-likelihood assuming AR1 noise model
+    Calculates a log-likelihood assuming AR(1) (autoregressive order 1)
+    errors. In this error model, the ith error term
+    :math:`\epsilon_i = x_i - f_i(\theta)` is assumed to obey the following
+    relationship.
 
     .. math::
-        \log{L(\theta, \sigma'|\boldsymbol{x})} =
-            -\frac{N}{2}\log{2\pi}
-            -N\log{\sigma'}
-            -\frac{1}{2\sigma'^2}
-                \sum_{i=2}^N{(\epsilon_i x_i - \rho \epsilon_{i-1} )^2}
+        \epsilon_i = \rho \epsilon_{i-1} + \nu_i
 
-    where
+    where :math:`\nu_i` is IID Gaussian white noise with variance
+    :math:`\sigma^2 (1-\rho^2)`. Therefore, this likelihood is appropriate when
+    the error terms are autocorrelated, and the parameter :math:`\rho`
+    determines the level of autocorrelation.
+
+    This class treats the error at the first time point (i=1) as fixed, which
+    simplifies the calculations. For sufficiently long time-series, this
+    conditioning on the first observation has at most a small effect on the
+    likelihood. Further details as well as the alternative unconditional
+    likelihood are available in [1]_ , chapter 5.2.
+
+    Noting that
 
     .. math::
-        \epsilon_i = x_i - f_i(\theta)
+        \nu_i = \epsilon_i - \rho \epsilon_{i-1} \sim N(0, \sigma^2 (1-\rho^2))
 
-    and
+    we thus calculate the likelihood as the product of normal likelihoods from
+    :math:`i=2,...,N`, for a time series with N time points.
 
     .. math::
-        \sigma' = \sigma \sqrt{1-\rho^2}
+        L(\theta, \sigma, \rho|\boldsymbol{x}) =
+            -\frac{N-1}{2} \log(2\pi)
+            - (N-1) \log(\sigma')
+            - \frac{1}{2\sigma'^2} \sum_{i=2}^N (\epsilon_i
+                                 - \rho \epsilon_{i-1})^2
 
-    .
+    for :math:`\sigma' = \sigma \sqrt{1-\rho^2}`.
 
     Extends :class:`ProblemLogLikelihood`.
 
@@ -44,6 +59,10 @@ class AR1LogLikelihood(pints.ProblemLogLikelihood):
         single-output problem two parameters are added (rho, sigma),
         for a multi-output problem 2 * ``n_outputs`` parameters are added.
 
+    References
+    ----------
+    .. [1] Hamilton, James D. Time series analysis. Vol. 2. New Jersey:
+           Princeton, 1994.
     """
 
     def __init__(self, problem):
@@ -73,29 +92,37 @@ class AR1LogLikelihood(pints.ProblemLogLikelihood):
 
 class ARMA11LogLikelihood(pints.ProblemLogLikelihood):
     r"""
-    Calculates a log-likelihood assuming ARMA(1,1) noise model.
+    Calculates a log-likelihood assuming ARMA(1,1) errors. The ARMA(1,1) model
+    has 1 autoregressive term and 1 moving average term. It assumes that the
+    errors :math:`\epsilon_i = x_i - f_i(\theta)` obey
 
     .. math::
-        \log{L(\theta, \sigma|\boldsymbol{x})} =
-            -\frac{N}{2}\log{2\pi}
-            -N\log{\sigma}
-            -\frac{1}{2\sigma^2}
-                \sum_{i=3}^N{(\nu_i - \phi \nu_{i-1})^2}
+        \epsilon_i = \nu_i + \rho \epsilon_{i-1} + \phi \nu_{i-1}
 
-    where
+    where :math:`\nu_i` is IID Gaussian white noise with standard deviation
+    :math:`\sigma'`.
+
+    .. math::
+        \sigma' = \sigma \sqrt{\frac{1 - \rho^2}{1 + 2  \phi  \rho + \phi^2}}
+
+    Due to the complexity of the exact ARMA(1,1) likelihood, this class
+    calculates a likelihood conditioned on initial values. This topic is
+    discussed further in [2]_ , chapter 5.6. Thus, for a time series defined at
+    points :math:`i=1,...,N`, summation begins at :math:`i=3`, and the
+    conditional likelihood is
+
+    .. math::
+        L(\theta, \sigma, \rho, \phi|\boldsymbol{x}) =
+            -\frac{N-2}{2} \log(2\pi)
+            - (N-2) \log(\sigma')
+            - \frac{1}{2\sigma'^2} \sum_{i=3}^N (\nu_i)^2
+
+    where the values of :math:`\nu_i` are calculated from the observations
+    according to
 
     .. math::
         \nu_i = \epsilon_i - \rho \epsilon_{i-1}
-
-    and
-
-    .. math::
-        \epsilon_i = x_i - f_i(\theta)
-
-    and
-
-    .. math::
-        \sigma = \sigma\sqrt{\frac{1-\rho^2}{1 + 2\phi\rho + \phi^2}}`
+        - \phi (\epsilon_{i-1} - \rho \epsilon_{i-2})
 
     Extends :class:`ProblemLogLikelihood`.
 
@@ -105,6 +132,11 @@ class ARMA11LogLikelihood(pints.ProblemLogLikelihood):
         A :class:`SingleOutputProblem` or :class:`MultiOutputProblem`. For a
         single-output problem three parameters are added (rho, phi, sigma),
         for a multi-output problem 3 * ``n_outputs`` parameters are added.
+
+    References
+    ----------
+    .. [2] Hamilton, James D. Time series analysis. Vol. 2. New Jersey:
+           Princeton, 1994.
     """
 
     def __init__(self, problem):

--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -14,8 +14,9 @@ import scipy.special
 
 class AR1LogLikelihood(pints.ProblemLogLikelihood):
     r"""
-    Calculates a log-likelihood assuming AR(1) (autoregressive order 1)
-    errors. In this error model, the ith error term
+    Calculates a log-likelihood assuming AR(1) (autoregressive order 1) errors.
+
+    In this error model, the ith error term
     :math:`\epsilon_i = x_i - f_i(\theta)` is assumed to obey the following
     relationship.
 
@@ -92,9 +93,10 @@ class AR1LogLikelihood(pints.ProblemLogLikelihood):
 
 class ARMA11LogLikelihood(pints.ProblemLogLikelihood):
     r"""
-    Calculates a log-likelihood assuming ARMA(1,1) errors. The ARMA(1,1) model
-    has 1 autoregressive term and 1 moving average term. It assumes that the
-    errors :math:`\epsilon_i = x_i - f_i(\theta)` obey
+    Calculates a log-likelihood assuming ARMA(1,1) errors.
+
+    The ARMA(1,1) model has 1 autoregressive term and 1 moving average term. It
+    assumes that the errors :math:`\epsilon_i = x_i - f_i(\theta)` obey
 
     .. math::
         \epsilon_i = \nu_i + \rho \epsilon_{i-1} + \phi \nu_{i-1}

--- a/pints/_log_likelihoods.py
+++ b/pints/_log_likelihoods.py
@@ -25,8 +25,11 @@ class AR1LogLikelihood(pints.ProblemLogLikelihood):
 
     where :math:`\nu_i` is IID Gaussian white noise with variance
     :math:`\sigma^2 (1-\rho^2)`. Therefore, this likelihood is appropriate when
-    the error terms are autocorrelated, and the parameter :math:`\rho`
+    error terms are autocorrelated, and the parameter :math:`\rho`
     determines the level of autocorrelation.
+
+    This model is parameterised as such because it leads to a simple marginal
+    distribution :math:`\epsilon_i \sim N(0, \sigma)`.
 
     This class treats the error at the first time point (i=1) as fixed, which
     simplifies the calculations. For sufficiently long time-series, this
@@ -99,13 +102,16 @@ class ARMA11LogLikelihood(pints.ProblemLogLikelihood):
     assumes that the errors :math:`\epsilon_i = x_i - f_i(\theta)` obey
 
     .. math::
-        \epsilon_i = \nu_i + \rho \epsilon_{i-1} + \phi \nu_{i-1}
+        \epsilon_i = \rho \epsilon_{i-1} + \nu_i + \phi \nu_{i-1}
 
     where :math:`\nu_i` is IID Gaussian white noise with standard deviation
     :math:`\sigma'`.
 
     .. math::
         \sigma' = \sigma \sqrt{\frac{1 - \rho^2}{1 + 2  \phi  \rho + \phi^2}}
+
+    This model is parameterised as such because it leads to a simple marginal
+    distribution :math:`\epsilon_i \sim N(0, \sigma)`.
 
     Due to the complexity of the exact ARMA(1,1) likelihood, this class
     calculates a likelihood conditioned on initial values. This topic is


### PR DESCRIPTION
Here's my current work on Small Issue #676. When this is finished, I think it should close #694 and #734 as well.

@ben18785  let me know if I've managed to get this correct and understandable. One of the main issues with these models seems to be the question of whether to work out the exact likelihood or condition on some initial observations for simplicity. In Pints it looks like the conditional likelihoods have been implemented, so I included that in the docstring. 

For both AR(1) and ARMA(1,1), we are currently using a transformed variance parameter for the white noise (e.g., sigma' = sigma sqrt{1-rho^2} for AR(1)). Is there a good justification or reference for these rescalings that you think we should mention in the docstring?