### PR TITLE
Made 'curve_fit' return the best parameters and final error function value

### DIFF
--- a/pints/_optimisers/__init__.py
+++ b/pints/_optimisers/__init__.py
@@ -883,6 +883,13 @@ def curve_fit(f, x, y, p0, boundaries=None, threshold=None, max_iter=None,
         The :class:`pints.Optimiser` to use. If no method is specified,
         ``pints.CMAES`` is used.
 
+    Returns
+    -------
+    xbest : numpy array
+        The best parameter set obtained.
+    fbest : float
+        The corresponding score.
+
     Example
     -------
     ::
@@ -938,8 +945,7 @@ def curve_fit(f, x, y, p0, boundaries=None, threshold=None, max_iter=None,
     opt.set_log_to_screen(True if verbose else False)
 
     # Run and return
-    popt, fopt = opt.run()
-    return popt
+    return opt.run()
 
 
 class _CurveFitError(pints.ErrorMeasure):

--- a/pints/tests/test_opt_easy_optimisation.py
+++ b/pints/tests/test_opt_easy_optimisation.py
@@ -10,6 +10,12 @@ import pints
 import unittest
 import numpy as np
 
+# Unit testing in Python 2 and 3
+try:
+    unittest.TestCase.assertRaisesRegex
+except AttributeError:
+    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+
 
 class TestEasyOptimisation(unittest.TestCase):
     """
@@ -28,7 +34,7 @@ class TestEasyOptimisation(unittest.TestCase):
         self.assertAlmostEqual(xopt[1], -5)
 
         # Function must be callable
-        self.assertRaisesRegexp(ValueError, 'callable', pints.fmin, 3, [1])
+        self.assertRaisesRegex(ValueError, 'callable', pints.fmin, 3, [1])
 
         # Test with boundaries
         xopt, fopt = pints.fmin(
@@ -60,17 +66,17 @@ class TestEasyOptimisation(unittest.TestCase):
 
         p0 = [0, 0, 0]
         np.random.seed(1)
-        popt = pints.curve_fit(g, x, y, p0, method=pints.XNES)
+        popt, fopt = pints.curve_fit(g, x, y, p0, method=pints.XNES)
         self.assertAlmostEqual(popt[0], 9, places=1)
         self.assertAlmostEqual(popt[1], 3, places=1)
         self.assertAlmostEqual(popt[2], 1, places=1)
 
         # Function must be callable
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, 'callable', pints.curve_fit, 3, x, y, p0)
 
         # Test with boundaries
-        pints.curve_fit(
+        popt, fopt = pints.curve_fit(
             g, x, y, p0,
             boundaries=([-10, -10, -10], [10, 10, 10]), method=pints.XNES)
         self.assertAlmostEqual(popt[0], 9, places=1)
@@ -82,7 +88,7 @@ class TestEasyOptimisation(unittest.TestCase):
 
         # Test with invalid sizes of `x` and `y`
         x = np.linspace(-5, 5, 99)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, 'dimension', pints.curve_fit, g, x, y, p0)
 
 


### PR DESCRIPTION
Closes #761.

Convenience method `curve_fit` now returns the final error function evaluation too, which makes it consistent with all other optimisation methods.

On the other hand, the user didn't actually define this error, so might not care about the value. So I'm happy to drop this PR too :D 