### PR TITLE
Fix matplotlib bug in surface

### DIFF
--- a/pints/plot/_surface.py
+++ b/pints/plot/_surface.py
@@ -326,11 +326,15 @@ def _voronoi_regions(x, y, f, xlim, ylim):
             selection.append(k)
 
     # Filter out bad regions
-    regions = np.array(regions)
+    regions = np.array(regions, dtype=object)
     regions = regions[selection]
     x = x[selection]
     y = y[selection]
     f = f[selection]
 
     # Return output
+    # Note: Regions is transformed back to a list, which fixes an issue with
+    # matplotlib 3.3.0 (which does not expect "ragged" ndarrays made of
+    # objects).
     return x, y, f, regions.tolist()
+

--- a/pints/plot/_surface.py
+++ b/pints/plot/_surface.py
@@ -333,5 +333,4 @@ def _voronoi_regions(x, y, f, xlim, ylim):
     f = f[selection]
 
     # Return output
-    return x, y, f, regions
-
+    return x, y, f, regions.tolist()

--- a/pints/tests/test_boundaries.py
+++ b/pints/tests/test_boundaries.py
@@ -11,6 +11,12 @@ import unittest
 import pints
 import numpy as np
 
+# Unit testing in Python 2 and 3
+try:
+    unittest.TestCase.assertRaisesRegex
+except AttributeError:
+    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+
 
 class TestRectangularBoundaries(unittest.TestCase):
     """
@@ -110,7 +116,7 @@ class TestLogPDFBoundaries(unittest.TestCase):
         self.assertFalse(b.check(0.75))
 
         # Test bad creation
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, 'must be a pints.LogPDF', pints.LogPDFBoundaries, 5, 5)
 
         # Can't sample from this log pdf!

--- a/pints/tests/test_plot.py
+++ b/pints/tests/test_plot.py
@@ -31,100 +31,103 @@ class TestPlot(unittest.TestCase):
     Tests Pints plot methods.
     """
 
-    def __init__(self, name):
-        super(TestPlot, self).__init__(name)
+    @classmethod
+    def setUpClass(cls):
+
+        # Number of samples: Make this as small as possible to speed up testing
+        n_samples = 300
 
         # Create toy model (single output)
-        self.model = toy.LogisticModel()
-        self.real_parameters = [0.015, 500]
-        self.times = np.linspace(0, 1000, 100)  # small problem
-        self.values = self.model.simulate(self.real_parameters, self.times)
+        cls.model = toy.LogisticModel()
+        cls.real_parameters = [0.015, 500]
+        cls.times = np.linspace(0, 1000, 100)  # small problem
+        cls.values = cls.model.simulate(cls.real_parameters, cls.times)
 
         # Add noise
-        self.noise = 10
-        self.values += np.random.normal(0, self.noise, self.values.shape)
-        self.real_parameters.append(self.noise)
-        self.real_parameters = np.array(self.real_parameters)
+        cls.noise = 10
+        cls.values += np.random.normal(0, cls.noise, cls.values.shape)
+        cls.real_parameters.append(cls.noise)
+        cls.real_parameters = np.array(cls.real_parameters)
 
         # Create an object with links to the model and time series
-        self.problem = pints.SingleOutputProblem(
-            self.model, self.times, self.values)
+        cls.problem = pints.SingleOutputProblem(
+            cls.model, cls.times, cls.values)
 
         # Create a uniform prior over both the parameters and the new noise
         # variable
-        self.lower = [0.01, 400, self.noise * 0.1]
-        self.upper = [0.02, 600, self.noise * 100]
-        self.log_prior = pints.UniformLogPrior(
-            self.lower,
-            self.upper
+        cls.lower = [0.01, 400, cls.noise * 0.1]
+        cls.upper = [0.02, 600, cls.noise * 100]
+        cls.log_prior = pints.UniformLogPrior(
+            cls.lower,
+            cls.upper
         )
 
         # Create a log likelihood
-        self.log_likelihood = pints.GaussianLogLikelihood(self.problem)
+        cls.log_likelihood = pints.GaussianLogLikelihood(cls.problem)
 
         # Create an un-normalised log-posterior (log-likelihood + log-prior)
-        self.log_posterior = pints.LogPosterior(
-            self.log_likelihood, self.log_prior)
+        cls.log_posterior = pints.LogPosterior(
+            cls.log_likelihood, cls.log_prior)
 
         # Run MCMC
-        self.x0 = [
-            self.real_parameters * 1.1,
-            self.real_parameters * 0.9,
-            self.real_parameters * 1.05
+        cls.x0 = [
+            cls.real_parameters * 1.1,
+            cls.real_parameters * 0.9,
+            cls.real_parameters * 1.05
         ]
-        mcmc = pints.MCMCController(self.log_posterior, 3, self.x0)
-        mcmc.set_max_iterations(300)  # make it as small as possible
+        mcmc = pints.MCMCController(cls.log_posterior, 3, cls.x0)
+        mcmc.set_max_iterations(n_samples)
         mcmc.set_log_to_screen(False)
-        self.samples = mcmc.run()
+        cls.samples = mcmc.run()
 
         # Create toy model (multi-output)
-        self.model2 = toy.LotkaVolterraModel()
-        self.real_parameters2 = self.model2.suggested_parameters()
-        self.times2 = self.model2.suggested_times()[::10]  # down sample it
-        self.values2 = self.model2.simulate(self.real_parameters2, self.times2)
+        cls.model2 = toy.LotkaVolterraModel()
+        cls.real_parameters2 = cls.model2.suggested_parameters()
+        cls.times2 = cls.model2.suggested_times()[::10]  # downsample it
+        cls.values2 = cls.model2.simulate(cls.real_parameters2, cls.times2)
 
         # Add noise
-        self.noise2 = 0.05
-        self.values2 += np.random.normal(0, self.noise2, self.values2.shape)
+        cls.noise2 = 0.05
+        cls.values2 += np.random.normal(0, cls.noise2, cls.values2.shape)
 
         # Create an object with links to the model and time series
-        self.problem2 = pints.MultiOutputProblem(
-            self.model2, self.times2, np.log(self.values2))
+        cls.problem2 = pints.MultiOutputProblem(
+            cls.model2, cls.times2, np.log(cls.values2))
 
         # Create a uniform prior over both the parameters and the new noise
         # variable
-        self.log_prior2 = pints.UniformLogPrior([0, 0, 0, 0], [6, 6, 6, 6])
+        cls.log_prior2 = pints.UniformLogPrior([0, 0, 0, 0], [6, 6, 6, 6])
         # Create a log likelihood
-        self.log_likelihood2 = pints.GaussianKnownSigmaLogLikelihood(
-            self.problem2, self.noise2)
+        cls.log_likelihood2 = pints.GaussianKnownSigmaLogLikelihood(
+            cls.problem2, cls.noise2)
 
         # Create an un-normalised log-posterior (log-likelihood + log-prior)
-        self.log_posterior2 = pints.LogPosterior(
-            self.log_likelihood2, self.log_prior2)
+        cls.log_posterior2 = pints.LogPosterior(
+            cls.log_likelihood2, cls.log_prior2)
 
         # Run MCMC
-        self.x02 = [
-            self.real_parameters2 * 1.1,
-            self.real_parameters2 * 0.9,
-            self.real_parameters2 * 1.05
+        cls.x02 = [
+            cls.real_parameters2 * 1.1,
+            cls.real_parameters2 * 0.9,
+            cls.real_parameters2 * 1.05
         ]
-        mcmc = pints.MCMCController(self.log_posterior2, 3, self.x02)
-        mcmc.set_max_iterations(300)  # make it as small as possible
+        mcmc = pints.MCMCController(cls.log_posterior2, 3, cls.x02)
+        mcmc.set_max_iterations(n_samples)
         mcmc.set_log_to_screen(False)
-        self.samples2 = mcmc.run()
+        cls.samples2 = mcmc.run()
 
         # Create toy model (single-output, single-parameter)
-        self.real_parameters3 = [0]
-        self.log_posterior3 = toy.GaussianLogPDF(self.real_parameters3, [1])
-        self.lower3 = [-3]
-        self.upper3 = [3]
+        cls.real_parameters3 = [0]
+        cls.log_posterior3 = toy.GaussianLogPDF(cls.real_parameters3, [1])
+        cls.lower3 = [-3]
+        cls.upper3 = [3]
 
         # Run MCMC
-        self.x03 = [[1], [-2], [3]]
-        mcmc = pints.MCMCController(self.log_posterior3, 3, self.x03)
-        mcmc.set_max_iterations(300)  # make it as small as possible
+        cls.x03 = [[1], [-2], [3]]
+        mcmc = pints.MCMCController(cls.log_posterior3, 3, cls.x03)
+        mcmc.set_max_iterations(n_samples)
         mcmc.set_log_to_screen(False)
-        self.samples3 = mcmc.run()
+        cls.samples3 = mcmc.run()
 
     def test_function(self):
         # Tests the function function.

--- a/pints/tests/test_plot.py
+++ b/pints/tests/test_plot.py
@@ -136,14 +136,14 @@ class TestPlot(unittest.TestCase):
         pints.plot.function(self.log_posterior, self.real_parameters,
                             self.lower, self.upper)
         # Check invalid lower bound
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             'Lower bounds must have same number of parameters as function',
             pints.plot.function, self.log_posterior,
             self.real_parameters, self.lower[:-1], self.upper
         )
         # Check invalid upper bound
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             'Upper bounds must have same number of parameters as function',
             pints.plot.function, self.log_posterior,
@@ -155,14 +155,14 @@ class TestPlot(unittest.TestCase):
             self.log_posterior, self.real_parameters, evaluations=5)
 
         # Check invalid function input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Given function must be pints\.LogPDF or pints\.ErrorMeasure\.',
             pints.plot.function, self.real_parameters, self.real_parameters
         )
 
         # Check invalid n_param input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Given point \`x\` must have same number of parameters as func',
             pints.plot.function,
@@ -170,7 +170,7 @@ class TestPlot(unittest.TestCase):
         )
 
         # Check invalid evaluations input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Number of evaluations must be greater than zero\.',
             pints.plot.function, self.log_posterior,
@@ -213,7 +213,7 @@ class TestPlot(unittest.TestCase):
                                            evaluations=5)
 
         # Check invalid function input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'Given function must be pints\.LogPDF or ' +
             r'pints\.ErrorMeasure\.', pints.plot.function_between_points,
             self.real_parameters,
@@ -222,7 +222,7 @@ class TestPlot(unittest.TestCase):
         )
 
         # Check invalid n_param input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'Both points must have the same number of parameters'
             r' as the given function\.', pints.plot.function_between_points,
             self.log_posterior,
@@ -231,7 +231,7 @@ class TestPlot(unittest.TestCase):
         )
 
         # Check invalid padding input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'Padding cannot be negative\.',
             pints.plot.function_between_points,
             self.log_posterior,
@@ -241,7 +241,7 @@ class TestPlot(unittest.TestCase):
         )
 
         # Check invalid evaluations input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'The number of evaluations must be 3 or greater\.',
             pints.plot.function_between_points,
             self.log_posterior,
@@ -283,7 +283,7 @@ class TestPlot(unittest.TestCase):
         pints.plot.histogram(few_samples, parameter_names=names)
 
         # Check invalid samples input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'All samples must have the same number of parameters\.',
             pints.plot.histogram,
@@ -291,7 +291,7 @@ class TestPlot(unittest.TestCase):
         )
 
         # Check invalid parameter_names input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Length of \`parameter\_names\` must be same as number of'
             r' parameters\.',
@@ -300,7 +300,7 @@ class TestPlot(unittest.TestCase):
         )
 
         # Check invalid ref_parameter input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Length of \`ref\_parameters\` must be same as number of'
             r' parameters\.',
@@ -337,14 +337,14 @@ class TestPlot(unittest.TestCase):
         pints.plot.trace(few_samples, parameter_names=names)
 
         # Check invalid samples input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'All samples must have the same number of parameters\.',
             pints.plot.trace, [self.samples[0, :, :], self.samples[1:, :, :-1]]
         )
 
         # Check invalid parameter_names input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Length of \`parameter\_names\` must be same as number of'
             r' parameters\.',
@@ -353,7 +353,7 @@ class TestPlot(unittest.TestCase):
         )
 
         # Check invalid ref_parameter input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Length of \`ref\_parameters\` must be same as number of',
             pints.plot.trace, self.samples,
@@ -381,13 +381,13 @@ class TestPlot(unittest.TestCase):
         pints.plot.autocorrelation(self.samples[0], parameter_names=names)
 
         # Check invalid input of samples
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'\`samples\` must be of shape \(n_sample\,'
             r' n_parameters\)\.', pints.plot.autocorrelation, self.samples
         )
 
         # Check invalid parameter_names input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Length of \`parameter\_names\` must be same as number of'
             r' parameters\.',
@@ -412,14 +412,14 @@ class TestPlot(unittest.TestCase):
         # Test thinning gives no error
         pints.plot.series(few_samples, self.problem, thinning=1)
         # Test invalid thinning input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'Thinning rate must be \`None\` or an integer'
             r' greater than zero\.', pints.plot.series, few_samples,
             self.problem, thinning=0
         )
 
         # Check invalid input of samples
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'\`samples\` must be of shape \(n_sample\,'
             r' n_parameters\)\.', pints.plot.series, self.samples, self.problem
         )
@@ -428,7 +428,7 @@ class TestPlot(unittest.TestCase):
         pints.plot.series(few_samples, self.problem,
                           ref_parameters=self.real_parameters)
         # Check invalid reference parameters input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'Length of \`ref_parameters\` must be same as number'
             r' of parameters\.', pints.plot.series, few_samples, self.problem,
             self.real_parameters[:-2]
@@ -442,14 +442,14 @@ class TestPlot(unittest.TestCase):
         # Test thinning gives no error
         pints.plot.series(few_samples2, self.problem2, thinning=1)
         # Test invalid thinning input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Thinning rate must be \`None\` or an integer greater than zero',
             pints.plot.series, few_samples2, self.problem2, thinning=0
         )
 
         # Check invalid input of samples
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'\`samples\` must be of shape \(n_sample\,'
             r' n_parameters\)\.', pints.plot.series, self.samples2,
             self.problem2
@@ -459,7 +459,7 @@ class TestPlot(unittest.TestCase):
         pints.plot.series(few_samples2, self.problem2,
                           ref_parameters=self.real_parameters2)
         # Check invalid reference parameters input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Length of \`ref_parameters\` must be same as number of'
             r' parameters\.',
@@ -488,7 +488,7 @@ class TestPlot(unittest.TestCase):
                             ref_parameters=self.real_parameters)
 
         # Check kde and heatmap error
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'Cannot use \`kde\` and \`heatmap\` together\.',
             pints.plot.pairwise, self.samples,
             kde=True, heatmap=True
@@ -508,13 +508,13 @@ class TestPlot(unittest.TestCase):
         pints.plot.pairwise(few_samples, parameter_names=names)
 
         # Check invalid input of samples
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'\`samples\` must be of shape \(n_sample\,'
             r' n_parameters\)\.', pints.plot.pairwise, self.samples
         )
 
         # Check invalid parameter_names input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Length of \`parameter\_names\` must be same as number of'
             r' parameters\.',
@@ -523,7 +523,7 @@ class TestPlot(unittest.TestCase):
         )
 
         # Check invalid ref_parameter input
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'Length of \`ref_parameters\` must be same as number'
             r' of parameters\.', pints.plot.pairwise,
             few_samples, ref_parameters=[self.real_parameters[0]]
@@ -532,7 +532,7 @@ class TestPlot(unittest.TestCase):
         # Test single parameter
         few_samples3 = self.samples3[0][::30, :]
         # Check this is invalid
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'Number of parameters must be larger than 2\.',
             pints.plot.pairwise, few_samples3
         )
@@ -560,19 +560,19 @@ class TestPlot(unittest.TestCase):
 
         # Points must be 2-dimensional
         bad_points = np.random.uniform(-2, 10, [20, 3])
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'two-dimensional parameters',
             pints.plot.surface, bad_points, values)
 
         # Number of values must match number of points
         bad_values = values[:-1]
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'number of values must match',
             pints.plot.surface, points, bad_values)
 
         # Three-dimensional boundaries
         bad_b = pints.RectangularBoundaries([0, 5, 1], [1, 9, 3])
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError, r'boundaries must be two-dimensional',
             pints.plot.surface, points, values, bad_b)
 

--- a/pints/tests/test_residuals_diagnostics.py
+++ b/pints/tests/test_residuals_diagnostics.py
@@ -88,7 +88,7 @@ class TestResidualsDiagnostics(unittest.TestCase):
                                                         thinning=10)
 
         # Check the message when the input is wrong dimension
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'\`parameters\` must be of shape \(n_samples\, n_parameters\)\.',
             pints.residuals_diagnostics.calculate_residuals,
@@ -97,7 +97,7 @@ class TestResidualsDiagnostics(unittest.TestCase):
         )
 
         # Check the message when the thinning is invalid
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'Thinning rate must be \`None\` or an integer greater than '
             r'zero\.',
@@ -159,7 +159,7 @@ class TestResidualsDiagnostics(unittest.TestCase):
         self.assertGreaterEqual(len(fig.axes), 2)
 
         # Test an invalid significance level
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'significance level must fall between 0 and 1',
             pints.residuals_diagnostics.plot_residuals_autocorrelation,
@@ -169,7 +169,7 @@ class TestResidualsDiagnostics(unittest.TestCase):
         )
 
         # Test an invalid credible interval
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'posterior interval must fall between 0 and 1',
             pints.residuals_diagnostics.plot_residuals_autocorrelation,
@@ -197,7 +197,7 @@ class TestResidualsDiagnostics(unittest.TestCase):
         self.assertGreaterEqual(len(fig.axes), 2)
 
         # Check the message when the input is wrong dimension
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             r'\`parameters\` must be of shape',
             pints.residuals_diagnostics.plot_residuals_vs_output,
@@ -206,7 +206,7 @@ class TestResidualsDiagnostics(unittest.TestCase):
         )
 
         # Check the message when the thinning is invalid
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             'Thinning rate must be',
             pints.residuals_diagnostics.plot_residuals_vs_output,


### PR DESCRIPTION
Here is a edit which appears to fix #1184 .

Having `_voronoi_regions` return a 1d numpy object array doesn't work with the latest matplotlib PolyCollection code. I think this should fix the broken unit test and notebook since matplotlib-3.3.0.