### PR TITLE
Experiments with standard library-based evaluators

### DIFF
--- a/pints/__init__.py
+++ b/pints/__init__.py
@@ -149,7 +149,9 @@ from ._error_measures import (
 from ._evaluation import (
     evaluate,
     Evaluator,
+    FuturesPoolEvaluator,
     ParallelEvaluator,
+    PoolEvaluator,
     SequentialEvaluator,
 )
 


### PR DESCRIPTION
At some stage, it'd be ideal if we could drop the parallel evaluator for something implemented in python's standard library

This draft PR explores some options