### PR TITLE
Documentation (and naming?) changes in pints.diagnostics

### DIFF
--- a/docs/source/diagnostics.rst
+++ b/docs/source/diagnostics.rst
@@ -1,6 +1,6 @@
-****************
-Diagnosting MCMC
-****************
+***********************
+Diagnosing MCMC results
+***********************
 
 .. currentmodule:: pints
 

--- a/pints/_diagnostics.py
+++ b/pints/_diagnostics.py
@@ -33,7 +33,7 @@ def autocorrelate_negative(autocorrelation):
 def ess_single_param(x):
     """
     Calculates effective sample size (ESS) for samples of a single parameter.
-    
+
     Parameters
     ----------
     x
@@ -48,9 +48,8 @@ def ess_single_param(x):
 
 def effective_sample_size(samples):
     """
-    Calculates effective sample size (ESS) for a list of n-dimensional
-    samples.
-    
+    Calculates effective sample size (ESS) for a list of n-dimensional samples.
+
     Parameters
     ----------
     samples

--- a/pints/_diagnostics.py
+++ b/pints/_diagnostics.py
@@ -48,7 +48,8 @@ def ess_single_param(x):
 
 def effective_sample_size(samples):
     """
-    Calculates effective sample size (ESS) for a list of n-dimensional samples.
+    Calculates effective sample size (ESS) for a list of n-dimensional
+    samples.
     
     Parameters
     ----------

--- a/pints/_diagnostics.py
+++ b/pints/_diagnostics.py
@@ -10,7 +10,7 @@ import numpy as np
 
 def autocorrelation(x):
     """
-    Calculate autocorrelation for a vector x using a spectrum density
+    Calculates autocorrelation for a vector ``x`` using a spectrum density
     calculation.
     """
     x = (x - np.mean(x)) / (np.std(x) * np.sqrt(len(x)))
@@ -32,7 +32,12 @@ def autocorrelate_negative(autocorrelation):
 
 def ess_single_param(x):
     """
-    Calculates ESS for a single parameter.
+    Calculates effective sample size (ESS) for samples of a single parameter.
+    
+    Parameters
+    ----------
+    x
+        A sequence (e.g. a list or a 1-dimensional array) of parameter values.
     """
     rho = autocorrelation(x)
     T = autocorrelate_negative(rho)
@@ -43,7 +48,12 @@ def ess_single_param(x):
 
 def effective_sample_size(samples):
     """
-    Calculates ESS for a matrix of samples.
+    Calculates effective sample size (ESS) for a list of n-dimensional samples.
+    
+    Parameters
+    ----------
+    samples
+        A 2d array of shape ``(n_samples, n_params)``.
     """
     try:
         n_samples, n_params = samples.shape

--- a/pints/_diagnostics.py
+++ b/pints/_diagnostics.py
@@ -53,7 +53,7 @@ def effective_sample_size(samples):
     Parameters
     ----------
     samples
-        A 2d array of shape ``(n_samples, n_params)``.
+        A 2d array of shape ``(n_samples, n_parameters)``.
     """
     try:
         n_samples, n_params = samples.shape


### PR DESCRIPTION
See also #1101

- [x] Improved docstring for ess_single_param
- [x] Improved docstring for effective_sample_size
- [ ] Update docstring for `autocorrelate_negative`: I don't understand what it does?
- [ ] Deprecate `ess_single_param` in favour of `effective_sample_size_single_parameter`, as we don't use "param" anywhere else in PINTS names, and the next method in the same file is called effective sample size ? Or should ess_single_param be private? It's not mentioned in the docs!