### PR TITLE
Documentation (and naming?) changes in pints.diagnostics: redux

### DIFF
--- a/examples/sampling/effective-sample-size.ipynb
+++ b/examples/sampling/effective-sample-size.ipynb
@@ -355,7 +355,7 @@
    "source": [
     "import pints._diagnostics as diagnostics\n",
     "\n",
-    "print('est. dependent (rho = 0.8) ESS = ' + str(diagnostics.ess_single_param(lXLowerRho)))"
+    "print('est. dependent (rho = 0.8) ESS = ' + str(diagnostics.effective_sample_size_single_parameter(lXLowerRho)))"
    ]
   }
  ],

--- a/pints/_diagnostics.py
+++ b/pints/_diagnostics.py
@@ -34,7 +34,12 @@ def _autocorrelate_negative(autocorrelation):
 
 def effective_sample_size_single_parameter(x):
     """
-    Calculates effective sample size (ESS) for a single parameter.
+    Calculates effective sample size (ESS) for samples of a single parameter.
+
+    Parameters
+    ----------
+    x
+        A sequence (e.g. a list or a 1-dimensional array) of parameter values.
     """
     rho = autocorrelation(x)
     T = _autocorrelate_negative(rho)
@@ -45,7 +50,12 @@ def effective_sample_size_single_parameter(x):
 
 def effective_sample_size(samples):
     """
-    Calculates effective sample size (ESS) for a matrix of samples.
+    Calculates effective sample size (ESS) for a list of n-dimensional samples.
+
+    Parameters
+    ----------
+    samples
+        A 2d array of shape ``(n_samples, n_parameters)``.
     """
     try:
         n_samples, n_params = samples.shape

--- a/pints/_diagnostics.py
+++ b/pints/_diagnostics.py
@@ -18,9 +18,11 @@ def autocorrelation(x):
     return result[int(result.size / 2):]
 
 
-def autocorrelate_negative(autocorrelation):
+def _autocorrelate_negative(autocorrelation):
     """
-    Finds last positive autocorrelation, T.
+    Takes a list of autocorrelations and finds the index of the last positive
+    element of the list before encountering a negative element. If no negative
+    element is found, it returns the index of the last element in the list.
     """
     T = 1
     for a in autocorrelation:
@@ -30,12 +32,12 @@ def autocorrelate_negative(autocorrelation):
     return T
 
 
-def ess_single_param(x):
+def effective_sample_size_single_parameter(x):
     """
-    Calculates ESS for a single parameter.
+    Calculates effective sample size (ESS) for a single parameter.
     """
     rho = autocorrelation(x)
-    T = autocorrelate_negative(rho)
+    T = _autocorrelate_negative(rho)
     n = len(x)
     ess = n / (1 + 2 * np.sum(rho[0:T]))
     return ess
@@ -43,7 +45,7 @@ def ess_single_param(x):
 
 def effective_sample_size(samples):
     """
-    Calculates ESS for a matrix of samples.
+    Calculates effective sample size (ESS) for a matrix of samples.
     """
     try:
         n_samples, n_params = samples.shape
@@ -52,7 +54,8 @@ def effective_sample_size(samples):
     if n_samples < 2:
         raise ValueError('At least two samples must be given.')
 
-    return [ess_single_param(samples[:, i]) for i in range(0, n_params)]
+    return [effective_sample_size_single_parameter(samples[:, i])
+            for i in range(0, n_params)]
 
 
 def _within(chains):
@@ -236,4 +239,3 @@ def rhat_all_params(chains):
         ' Please use `pints.rhat` instead.')
 
     return rhat(chains)
-

--- a/pints/_diagnostics.py
+++ b/pints/_diagnostics.py
@@ -20,16 +20,13 @@ def autocorrelation(x):
 
 def _autocorrelate_negative(autocorrelation):
     """
-    Takes a list of autocorrelations and finds the index of the last positive
-    element of the list before encountering a negative element. If no negative
-    element is found, it returns the index of the last element in the list.
+    Returns the index of the first negative entry in ``autocorrelation``, or
+    ``len(autocorrelation)`` if no negative entry is found.
     """
-    T = 1
-    for a in autocorrelation:
-        if a < 0:
-            return T - 1
-        T += 1
-    return T
+    try:
+        return np.where(np.asarray(autocorrelation) < 0)[0][0]
+    except IndexError:
+        return len(autocorrelation)
 
 
 def effective_sample_size_single_parameter(x):

--- a/pints/tests/test_diagnostics.py
+++ b/pints/tests/test_diagnostics.py
@@ -38,24 +38,25 @@ class TestDiagnostics(unittest.TestCase):
 
         # Test for case where there is a negative element
         x = np.array([1, 2, 3, 4, -1, -1])
-        self.assertEqual(pints._diagnostics.autocorrelate_negative(x), 4)
+        self.assertEqual(pints._diagnostics._autocorrelate_negative(x), 4)
 
         # Test for case with no negative elements
         x = np.array([1, 2, 3, 4, 1, 1])
-        self.assertEqual(pints._diagnostics.autocorrelate_negative(x), 7)
+        self.assertEqual(pints._diagnostics._autocorrelate_negative(x), 7)
 
-    def test_ess_single_param(self):
+    def test_effective_sample_size_single_parameter(self):
         # Tests that ESS for a single parameter is correct
 
         # For case with negative elements in x
         x = np.array([1, 2, 3, 4, -1, -1])
-        y = pints._diagnostics.ess_single_param(x)
+        y = pints._diagnostics.effective_sample_size_single_parameter(x)
         self.assertAlmostEqual(y, 1.75076, 5)
 
         # Case with positive elements only in x
         x = np.array([1, 2, 3, 4, 1, 1])
         self.assertAlmostEqual(
-            pints._diagnostics.ess_single_param(x), 1.846154, 6)
+            pints._diagnostics.effective_sample_size_single_parameter(x),
+            1.846154, 6)
 
     def test_effective_sample_size(self):
         # Tests ess for a matrix of parameters

--- a/pints/tests/test_diagnostics.py
+++ b/pints/tests/test_diagnostics.py
@@ -42,7 +42,7 @@ class TestDiagnostics(unittest.TestCase):
 
         # Test for case with no negative elements
         x = np.array([1, 2, 3, 4, 1, 1])
-        self.assertEqual(pints._diagnostics._autocorrelate_negative(x), 7)
+        self.assertEqual(pints._diagnostics._autocorrelate_negative(x), 6)
 
     def test_effective_sample_size_single_parameter(self):
         # Tests that ESS for a single parameter is correct


### PR DESCRIPTION
See #1101 

- [x] Update docstring for autocorrelate_negative: I don't understand what it does?
- [x] Deprecate ess_single_param in favour of effective_sample_size_single_parameter, as we don't use "param" anywhere else in PINTS names, and the next method in the same file is called effective sample size ?
- [x] Haven't made effective_sample_size_single_parameter private as I can imagine wanting to use it