### PR TITLE
Make automated tests run only for non-draft PRs

### DIFF
--- a/.github/workflows/copyright-test.yml
+++ b/.github/workflows/copyright-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [review_requested, ready_for_review]
     branches:
       - '**'
 

--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [review_requested, ready_for_review]
     branches:
       - '**'
 

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [review_requested, ready_for_review]
     branches:
       - '**'
 

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [review_requested, ready_for_review]
     branches:
       - '**'
 

--- a/.github/workflows/unit-test-os-coverage.yml
+++ b/.github/workflows/unit-test-os-coverage.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [review_requested, ready_for_review]
     branches:
       - '**'
 

--- a/.github/workflows/unit-test-python-coverage.yml
+++ b/.github/workflows/unit-test-python-coverage.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [review_requested, ready_for_review]
     branches:
       - '**'
 


### PR DESCRIPTION
- adds `types: [review_requested, ready_for_review]` to those workflows that run on PRs