### PR TITLE
Skip draft PRs, but run when a draft is marked as ready for review

### DIFF
--- a/.github/workflows/copyright-test.yml
+++ b/.github/workflows/copyright-test.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
   pull_request:
-    if: github.event.pull_request.draft == false
+    # Run workflow when PR is changed, or when changed from draft to ready
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '**'
 
@@ -14,6 +15,9 @@ jobs:
   build-and-test:
     name: Copyright
     runs-on: ubuntu-latest
+
+    # Skip job if it's a draft PR
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
   pull_request:
-    if: github.event.pull_request.draft == false
+    # Run workflow when PR is changed, or when changed from draft to ready
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '**'
 
@@ -14,6 +15,9 @@ jobs:
   build-and-test:
     name: Coverage
     runs-on: ubuntu-latest
+
+    # Skip job if it's a draft PR
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
   pull_request:
-    if: github.event.pull_request.draft == false
+    # Run workflow when PR is changed, or when changed from draft to ready
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '**'
 
@@ -14,6 +15,9 @@ jobs:
   build-and-test:
     name: Docs
     runs-on: ubuntu-latest
+
+    # Skip job if it's a draft PR
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
   pull_request:
-    if: github.event.pull_request.draft == false
+    # Run workflow when PR is changed, or when changed from draft to ready
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '**'
 
@@ -14,6 +15,9 @@ jobs:
   build-and-test:
     name: Style
     runs-on: ubuntu-latest
+
+    # Skip job if it's a draft PR
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/unit-test-os-coverage.yml
+++ b/.github/workflows/unit-test-os-coverage.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
   pull_request:
-    if: github.event.pull_request.draft == false
+    # Run workflow when PR is changed, or when changed from draft to ready
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '**'
 
@@ -14,6 +15,9 @@ jobs:
   build-and-test:
     name: OS unit tests
     runs-on: ${{ matrix.os }}
+
+    # Skip job if it's a draft PR
+    if: github.event.pull_request.draft == false
 
     strategy:
       matrix:

--- a/.github/workflows/unit-test-python-coverage.yml
+++ b/.github/workflows/unit-test-python-coverage.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
   pull_request:
-    if: github.event.pull_request.draft == false
+    # Run workflow when PR is changed, or when changed from draft to ready
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '**'
 
@@ -14,6 +15,9 @@ jobs:
   build-and-test:
     name: Python unit tests
     runs-on: ubuntu-latest
+
+    # Skip job if it's a draft PR
+    if: github.event.pull_request.draft == false
 
     strategy:
       matrix:


### PR DESCRIPTION
Hi both!

I think I've worked out the full syntax to do this?

- The first line is new, and updates the list of "events" on a PR that trigger checks
  https://docs.github.com/en/enterprise-server@3.0/actions/reference/events-that-trigger-workflows
  It adds "ready_to_review" to the 3 default events, which means that going from draft to normal PR now triggers checks

- The second line is the one Ben added, & which Fergus correctly moved to the job. (I don't understand why, it looks more natural in the above bit to me, but that doesn't work!)

**Update** forgot to create the first PR as draft to show that this works