### PR TITLE
Fixed Neal's Funnel Derivative bug

### DIFF
--- a/pints/toy/_neals_funnel.py
+++ b/pints/toy/_neals_funnel.py
@@ -73,6 +73,7 @@ class NealsFunnelLogPDF(ToyLogPDF):
         dnu = np.sum(dnu_first) - nu / 9.0
         dL = [-var * cons for var in x_temp]
         dL.append(dnu)
+        dL = np.array(dL)
         return L, dL
 
     def kl_divergence(self, samples):


### PR DESCRIPTION
The derivative of Neal's Funnel is now returned(in the evaluateS1 function) as a numpy array which makes it usable with NUTS.