### PR TITLE
Subcapture warning pt 2

### DIFF
--- a/pints/_evaluation.py
+++ b/pints/_evaluation.py
@@ -452,7 +452,7 @@ class _Worker(multiprocessing.Process):
 
     def run(self):
         # Worker processes should never write to stdout or stderr.
-        # This can lead to unsafe situations if they have been redicted to
+        # This can lead to unsafe situations if they have been redirected to
         # a GUI task such as writing to the IDE console.
         sys.stdout = open(os.devnull, 'w')
         sys.stderr = open(os.devnull, 'w')

--- a/pints/tests/shared.py
+++ b/pints/tests/shared.py
@@ -27,7 +27,7 @@ class StreamCapture(object):
     A context manager that redirects and captures the output stdout, stderr,
     or both.
 
-    Warning: This class is not thread-safe (or multiprocessing-safe).
+    Warning: This class is not thread-safe.
     """
     def __init__(self, stdout=True, stderr=False):
         super(StreamCapture, self).__init__()
@@ -149,7 +149,7 @@ class SubCapture(object):
     The argument ``dump_on_error`` can be set to ``True`` to print all output
     if an error occurs while the context manager is active.
 
-    Warning: This class is not thread-safe (or multiprocessing-safe).
+    Warning: This class is not thread-safe.
     """
     def __init__(self, dump_on_error=False):
         super(SubCapture, self).__init__()


### PR DESCRIPTION
Hi @martinjrobins !

I did a bit of testing and it looks like these capture methods should be OK when used in multiprocessing: https://github.com/MichaelClerx/myokit/issues/727
I've checked with `spawn` and `fork`, so should handle the windows & linux defaults

So I've downgradedd the warning to "not thread safe" (which I think is the issue you were having)

This is good news w.r.t. myokit as well, as it's much easier to make it thread-safe than it would be to fix similar issues for multiprocessing!