### PR TITLE
Updated sphinx conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,17 +40,10 @@ extensions = [
 ]
 
 # Autodoc defaults
-if int(sphinx.__version__.split('.')[1]) < 8:
-    autodoc_default_flags = [
-        'members',
-        'inherited-members',
-        # 'show-inheritance',
-    ]
-else:
-    autodoc_default_options = {
-        'members': None,
-        'inherited-members': None,
-    }
+autodoc_default_options = {
+    'members': None,
+    'inherited-members': None,
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -66,7 +59,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Pints'
-copyright = u'2019, Pints Authors'
+copyright = u'2021, Pints Authors'
 author = u'Pints Authors'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,11 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
 import pints
-import sphinx
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
- Removed use of [`autodoc_default_flags`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_flags), because:
  - It was deprecated in 1.8, sphinx is now onto 4.x
  - The check to see which version to use assumed we were still on 1.x
- Changed copyright year from 2019 to 2021