### PR TITLE
Fix alpha equation for MALAMCMC

### DIFF
--- a/pints/_mcmc/_mala.py
+++ b/pints/_mcmc/_mala.py
@@ -47,7 +47,7 @@ class MALAMCMC(pints.SingleChainMCMC):
     after a step,
 
     .. math::
-        \alpha = \frac{\pi(\theta^*)q(\theta_t|\theta^*)}{\pi(\theta^*)
+        \alpha = \frac{\pi(\theta^*)q(\theta_t|\theta^*)}{\pi(\theta_t)
             q(\theta^*|\theta_t)}
 
     where :math:`q(\theta_2|\theta_1) =


### PR DESCRIPTION
The equation for `alpha` seems to have a typo in which `\theta^*` was present in the nominator and denominator. The correct version should be with `\theta_t` in the denominator, see https://en.wikipedia.org/wiki/Metropolis-adjusted_Langevin_algorithm.