### PR TITLE
Made pints.evaluate() limit the number of workers to the number of jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - [#1191](https://github.com/pints-team/pints/pull/1191) Warnings are now emitted using `warnings.warn` rather than `logging.getLogger(..).warning`. This makes them show up like other warnings, and allows them to be suppressed with [filterwarnings](https://docs.python.org/3/library/warnings.html#warnings.filterwarnings).
 - [#1112](https://github.com/pints-team/pints/pull/1112) The new NUTS method is only supported on Python 3.3 and newer; a warning will be emitted when importing PINTS in older versions.
 - [#1112](https://github.com/pints-team/pints/pull/1112) The `pints.Logger` can now deal with `None` being logged in place of a proper value.
+- [#1355](https://github.com/pints-team/pints/pull/1112) When called with `parallel=True` the method `pints.evaluate()` will now limit the number of workers it uses to the number of tasks it needs to process.
 ### Deprecated
 - [#1201](https://github.com/pints-team/pints/pull/1201) The method `pints.rhat_all_params` was accidentally removed in 0.3.0, but is now back in deprecated form.
 ### Removed

--- a/pints/_evaluation.py
+++ b/pints/_evaluation.py
@@ -48,7 +48,8 @@ def evaluate(f, x, parallel=False, args=None):
 
     """
     if parallel is True:
-        evaluator = ParallelEvaluator(f, args=args)
+        n_workers = max(min(ParallelEvaluator.cpu_count(), len(x)), 1)
+        evaluator = ParallelEvaluator(f, n_workers=n_workers, args=args)
     elif parallel >= 1:
         evaluator = ParallelEvaluator(f, n_workers=int(parallel), args=args)
     else:


### PR DESCRIPTION
Made `pints.evaluate()` limit the number of workers to the number of jobs, to avoid having unneeded workers.

Note we can't do this in `ParallelEvaluator`, where the number of jobs is unknown and variable