### PR TITLE
Restrict numpy multithreading when multiprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file.
 - [#1191](https://github.com/pints-team/pints/pull/1191) Warnings are now emitted using `warnings.warn` rather than `logging.getLogger(..).warning`. This makes them show up like other warnings, and allows them to be suppressed with [filterwarnings](https://docs.python.org/3/library/warnings.html#warnings.filterwarnings).
 - [#1112](https://github.com/pints-team/pints/pull/1112) The new NUTS method is only supported on Python 3.3 and newer; a warning will be emitted when importing PINTS in older versions.
 - [#1112](https://github.com/pints-team/pints/pull/1112) The `pints.Logger` can now deal with `None` being logged in place of a proper value.
-- [#1355](https://github.com/pints-team/pints/pull/1112) When called with `parallel=True` the method `pints.evaluate()` will now limit the number of workers it uses to the number of tasks it needs to process.
+- [#1355](https://github.com/pints-team/pints/pull/1355) When called with `parallel=True` the method `pints.evaluate()` will now limit the number of workers it uses to the number of tasks it needs to process.
+- [#1357](https://github.com/pints-team/pints/pull/1357) Parallel evaluations using multiprocessing now restrict the number of threads used by Numpy and others to 1 (by default).
 ### Deprecated
 - [#1201](https://github.com/pints-team/pints/pull/1201) The method `pints.rhat_all_params` was accidentally removed in 0.3.0, but is now back in deprecated form.
 ### Removed

--- a/pints/_evaluation.py
+++ b/pints/_evaluation.py
@@ -470,11 +470,10 @@ class _Worker(multiprocessing.Process):
         self._tasks = tasks
         self._results = results
         self._max_tasks = max_tasks
+        self._max_threads = \
+            None if max_threads is None else max(0, int(max_threads))
         self._errors = errors
         self._error = error
-
-        # Use ``None`` to indicate current behaviour (no change)
-        self._threads = None if n_numpy_threads < 1 else int(n_numpy_threads)
 
     def run(self):
         # Worker processes should never write to stdout or stderr.
@@ -483,7 +482,7 @@ class _Worker(multiprocessing.Process):
         sys.stdout = open(os.devnull, 'w')
         sys.stderr = open(os.devnull, 'w')
         try:
-            with threadpoolctl.threadpool_limits(self._n_numpy_threads):
+            with threadpoolctl.threadpool_limits(self._max_threads):
                 for k in range(self._max_tasks):
                     i, x = self._tasks.get()
                     f = self._function(x, *self._args)

--- a/pints/tests/test_evaluators.py
+++ b/pints/tests/test_evaluators.py
@@ -113,10 +113,13 @@ class TestEvaluators(unittest.TestCase):
         tasks.put((0, 1))
         tasks.put((1, 2))
         tasks.put((2, 3))
+
         max_tasks = 3
+        max_threads = 1
 
         w = Worker(
-            interrupt_on_30, (), tasks, results, max_tasks, errors, error)
+            interrupt_on_30, (), tasks, results, max_tasks, max_threads,
+            errors, error)
         w.run()
 
         self.assertEqual(results.get(timeout=0.01), (0, 2))
@@ -135,7 +138,8 @@ class TestEvaluators(unittest.TestCase):
         error.set()
 
         w = Worker(
-            interrupt_on_30, (), tasks, results, max_tasks, errors, error)
+            interrupt_on_30, (), tasks, results, max_tasks, max_threads,
+            errors, error)
         w.run()
 
         self.assertEqual(results.get(timeout=0.01), (0, 2))
@@ -151,7 +155,8 @@ class TestEvaluators(unittest.TestCase):
         tasks.put((2, 3))
 
         w = Worker(
-            interrupt_on_30, (), tasks, results, max_tasks, errors, error)
+            interrupt_on_30, (), tasks, results, max_tasks, max_threads,
+            errors, error)
         w.run()
 
         self.assertEqual(results.get(timeout=0.01), (0, 2))

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,6 @@
 #  For licensing information, see the LICENSE file distributed with the PINTS
 #  software package.
 #
-import os
-import sys
-
 from setuptools import setup, find_packages
 
 # Load text for description and license
@@ -19,27 +16,13 @@ with open('README.md') as f:
 # Read version number from file
 def load_version():
     try:
+        import os
         root = os.path.abspath(os.path.dirname(__file__))
         with open(os.path.join(root, 'pints', 'version'), 'r') as f:
             version = f.read().strip().split(',')
         return '.'.join([str(int(x)) for x in version])
     except Exception as e:
         raise RuntimeError('Unable to read version number (' + str(e) + ').')
-
-
-# Required packages for basic install
-requirements = [
-    'cma>=2',
-    'numpy>=1.8',
-    'scipy>=0.14',
-    # Note: Matplotlib is loaded for debug plots, but to ensure pints runs
-    # on systems without an attached display, it should never be imported
-    # outside of plot() methods.
-    'matplotlib>=1.5',
-    'tabulate',
-]
-if sys.version_info[0] > 2:
-    requirements.append('threadpoolctl')
 
 
 # Go!
@@ -70,7 +53,17 @@ setup(
     include_package_data=True,
 
     # List of dependencies
-    install_requires=requirements,
+    install_requires=[
+        'cma>=2',
+        'numpy>=1.8',
+        'scipy>=0.14',
+        # Note: Matplotlib is loaded for debug plots, but to ensure pints runs
+        # on systems without an attached display, it should never be imported
+        # outside of plot() methods.
+        'matplotlib>=1.5',
+        'tabulate',
+        'threadpoolctl',
+    ],
     extras_require={
         'docs': [
             'sphinx>=1.5, !=1.7.3',     # For doc generation

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@
 #  For licensing information, see the LICENSE file distributed with the PINTS
 #  software package.
 #
+import os
+import sys
+
 from setuptools import setup, find_packages
 
 # Load text for description and license
@@ -16,13 +19,27 @@ with open('README.md') as f:
 # Read version number from file
 def load_version():
     try:
-        import os
         root = os.path.abspath(os.path.dirname(__file__))
         with open(os.path.join(root, 'pints', 'version'), 'r') as f:
             version = f.read().strip().split(',')
         return '.'.join([str(int(x)) for x in version])
     except Exception as e:
         raise RuntimeError('Unable to read version number (' + str(e) + ').')
+
+
+# Required packages for basic install
+requirements = [
+    'cma>=2',
+    'numpy>=1.8',
+    'scipy>=0.14',
+    # Note: Matplotlib is loaded for debug plots, but to ensure pints runs
+    # on systems without an attached display, it should never be imported
+    # outside of plot() methods.
+    'matplotlib>=1.5',
+    'tabulate',
+]
+if sys.version_info[0] > 2:
+    requirements.append('threadpoolctl')
 
 
 # Go!
@@ -53,17 +70,7 @@ setup(
     include_package_data=True,
 
     # List of dependencies
-    install_requires=[
-        'cma>=2',
-        'numpy>=1.8',
-        'scipy>=0.14',
-        # Note: Matplotlib is loaded for debug plots, but to ensure pints runs
-        # on systems without an attached display, it should never be imported
-        # outside of plot() methods.
-        'matplotlib>=1.5',
-        'tabulate',
-        'threadpoolctl',
-    ],
+    install_requires=requirements,
     extras_require={
         'docs': [
             'sphinx>=1.5, !=1.7.3',     # For doc generation

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         # outside of plot() methods.
         'matplotlib>=1.5',
         'tabulate',
+        'threadpoolctl',
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
See #1356 

Current solution allows customisation of `ParallelEvaluator` class, but doesn't provide options for the `pints.evaluate` method or for controllers (which just use the new default)