### PR TITLE
Seed worker threads for different, but reproducible, results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file.
 - [#1191](https://github.com/pints-team/pints/pull/1191) Warnings are now emitted using `warnings.warn` rather than `logging.getLogger(..).warning`. This makes them show up like other warnings, and allows them to be suppressed with [filterwarnings](https://docs.python.org/3/library/warnings.html#warnings.filterwarnings).
 - [#1112](https://github.com/pints-team/pints/pull/1112) The new NUTS method is only supported on Python 3.3 and newer; a warning will be emitted when importing PINTS in older versions.
 - [#1112](https://github.com/pints-team/pints/pull/1112) The `pints.Logger` can now deal with `None` being logged in place of a proper value.
-- [#1355](https://github.com/pints-team/pints/pull/1112) When called with `parallel=True` the method `pints.evaluate()` will now limit the number of workers it uses to the number of tasks it needs to process.
+- [#1355](https://github.com/pints-team/pints/pull/1355) When called with `parallel=True` the method `pints.evaluate()` will now limit the number of workers it uses to the number of tasks it needs to process.
+- [#1360](https://github.com/pints-team/pints/pull/1360) The `ParallelEvaluator` will now set a different (pre-determined) random seed for each task, ensuring tasks can use randomness, but results can be reproduced from run to run.
 ### Deprecated
 - [#1201](https://github.com/pints-team/pints/pull/1201) The method `pints.rhat_all_params` was accidentally removed in 0.3.0, but is now back in deprecated form.
 ### Removed

--- a/pints/_evaluation.py
+++ b/pints/_evaluation.py
@@ -24,6 +24,13 @@ def evaluate(f, x, parallel=False, args=None):
     Evaluates the function ``f`` on every value present in ``x`` and returns
     a sequence of evaluations ``f(x[i])``.
 
+    It is possible for the evaluation of ``f`` to involve the generation of
+    random numbers (using numpy). In this case, the results from calling
+    ``evaluate`` can be made reproducible by first seeding numpy's generator
+    with a fixed number. However, a call with ``parallel=True`` will use a
+    different (but consistent) sequence of random numbers than a call with
+    ``parallel=False``.
+
     Parameters
     ----------
     f : callable
@@ -41,7 +48,6 @@ def evaluate(f, x, parallel=False, args=None):
     args : sequence
         Optional extra arguments to pass into ``f``.
 
-
     """
     if parallel is True:
         n_workers = max(min(ParallelEvaluator.cpu_count(), len(x)), 1)
@@ -56,10 +62,19 @@ def evaluate(f, x, parallel=False, args=None):
 class Evaluator(object):
     """
     Abstract base class for classes that take a function (or callable object)
-    ``f(x)`` and evaluate it for list of input values ``x``. This interface is
-    shared by a parallel and a sequential implementation, allowing easy
-    switching between parallel or sequential implementations of the same
-    algorithm.
+    ``f(x)`` and evaluate it for list of input values ``x``.
+
+    This interface is shared by a parallel and a sequential implementation,
+    allowing easy switching between parallel or sequential implementations of
+    the same algorithm.
+
+    It is possible for the evaluation of ``f`` to involve the generation of
+    random numbers (using numpy). In this case, the results from calling
+    ``evaluate`` can be made reproducible by first seeding numpy's generator
+    with a fixed number. However, different ``Evaluator`` implementations may
+    use a different random sequence. In other words, each Evaluator can be made
+    to return consistent results, but the results returned by different
+    Evaluators may vary.
 
     Parameters
     ----------

--- a/pints/_evaluation.py
+++ b/pints/_evaluation.py
@@ -281,7 +281,10 @@ multiprocessing.html#all-platforms>`_ for details).
         #     sequences within each task will be reproducible. Note that we
         #     cannot achieve this by seeding the worker processes once, as the
         #     allocation of tasks to workers is not deterministic.
-        seeds = np.random.randint(0, 2**32, len(positions))
+        # The upper bound is chosen to get a wide range and still work on all
+        # systems. Windows, in particular, seems to insist on a 32 bit int even
+        # in Python 3.9.
+        seeds = np.random.randint(0, 2**16, len(positions))
 
         # Start
         try:

--- a/pints/tests/test_evaluators.py
+++ b/pints/tests/test_evaluators.py
@@ -234,7 +234,7 @@ def system_exit_on_four(x):
 
 
 def random_int(x):
-    return np.random.randint(2**32)
+    return np.random.randint(2**16)
 
 
 if __name__ == '__main__':

--- a/pints/tests/test_evaluators.py
+++ b/pints/tests/test_evaluators.py
@@ -6,9 +6,11 @@
 # released under the BSD 3-clause license. See accompanying LICENSE.md for
 # copyright notice and full license details.
 #
+import numpy as np
 import pints
 import unittest
-import numpy as np
+import time
+
 
 # Consistent unit testing in Python 2 and 3
 try:
@@ -99,6 +101,46 @@ class TestEvaluators(unittest.TestCase):
             Exception, 'Exception in subprocess', e.evaluate, [1, 2, 4])
         e.evaluate([1, 2])
 
+    def test_parallel_random(self):
+        # Test parallel processes get different random seed, but are
+        # reproducible.
+
+        # Ensure that worker processes don't all use the same random sequence
+        # To test this, generate a random number in each task, and check that
+        # the numbers don't match. With max-tasks-per-worker at 1, they should
+        # all be the same without seeding.
+        n = 20
+        e = pints.ParallelEvaluator(
+            random_int, n_workers=n, max_tasks_per_worker=1)
+        x = np.array(e.evaluate([0]*n))
+        self.assertFalse(np.all(x == x[0]))
+
+        # Without max-tasks-per-worker, we still expect most workers to do 1
+        # task, and some to do 2, maybe even three.
+        e = pints.ParallelEvaluator(random_int, n_workers=n)
+        x = set(e.evaluate([0]*n))
+        self.assertTrue(len(x) > n // 2)
+
+        # Getting the same numbers twice should be very unlikely
+        x = np.array(e.evaluate([0]*n))
+        y = np.array(e.evaluate([0]*n))
+        #self.assertFalse(np.all(x) == np.all(y))
+        self.assertTrue(len(set(x) | set(y)) > n // 2)
+
+        # But with seeding we expect the same result twice
+        np.random.seed(123)
+        x = np.array(e.evaluate([0]*n))
+        np.random.seed(123)
+        y = np.array(e.evaluate([0]*n))
+        self.assertTrue(np.all(x) == np.all(y))
+
+        # Even with many more tasks than workers
+        e = pints.ParallelEvaluator(random_int, n_workers=3)
+        np.random.seed(123)
+        x = np.array(e.evaluate([0]*100))
+        np.random.seed(123)
+        y = np.array(e.evaluate([0]*100))
+
     def test_worker(self):
         # Manual test of worker, since cover doesn't pick up on its run method.
 
@@ -110,9 +152,9 @@ class TestEvaluators(unittest.TestCase):
         results = multiprocessing.Queue()
         errors = multiprocessing.Queue()
         error = multiprocessing.Event()
-        tasks.put((0, 1))
-        tasks.put((1, 2))
-        tasks.put((2, 3))
+        tasks.put((0, 0, 1))
+        tasks.put((1, 1, 2))
+        tasks.put((2, 2, 3))
         max_tasks = 3
 
         w = Worker(
@@ -129,9 +171,9 @@ class TestEvaluators(unittest.TestCase):
         results = multiprocessing.Queue()
         errors = multiprocessing.Queue()
         error = multiprocessing.Event()
-        tasks.put((0, 1))
-        tasks.put((1, 2))
-        tasks.put((2, 3))
+        tasks.put((0, 200, 1))
+        tasks.put((1, 201, 2))
+        tasks.put((2, 202, 3))
         error.set()
 
         w = Worker(
@@ -146,9 +188,9 @@ class TestEvaluators(unittest.TestCase):
         results = multiprocessing.Queue()
         errors = multiprocessing.Queue()
         error = multiprocessing.Event()
-        tasks.put((0, 1))
-        tasks.put((1, 30))
-        tasks.put((2, 3))
+        tasks.put((0, 100, 1))
+        tasks.put((1, 400, 30))
+        tasks.put((2, 200, 3))
 
         w = Worker(
             interrupt_on_30, (), tasks, results, max_tasks, errors, error)
@@ -190,6 +232,10 @@ def system_exit_on_four(x):
     if x == 4:
         raise SystemExit
     return x
+
+
+def random_int(x):
+    return np.random.randint(2**32)
 
 
 if __name__ == '__main__':

--- a/pints/tests/test_evaluators.py
+++ b/pints/tests/test_evaluators.py
@@ -9,7 +9,6 @@
 import numpy as np
 import pints
 import unittest
-import time
 
 
 # Consistent unit testing in Python 2 and 3
@@ -112,34 +111,34 @@ class TestEvaluators(unittest.TestCase):
         n = 20
         e = pints.ParallelEvaluator(
             random_int, n_workers=n, max_tasks_per_worker=1)
-        x = np.array(e.evaluate([0]*n))
+        x = np.array(e.evaluate([0] * n))
         self.assertFalse(np.all(x == x[0]))
 
         # Without max-tasks-per-worker, we still expect most workers to do 1
         # task, and some to do 2, maybe even three.
         e = pints.ParallelEvaluator(random_int, n_workers=n)
-        x = set(e.evaluate([0]*n))
+        x = set(e.evaluate([0] * n))
         self.assertTrue(len(x) > n // 2)
 
         # Getting the same numbers twice should be very unlikely
-        x = np.array(e.evaluate([0]*n))
-        y = np.array(e.evaluate([0]*n))
+        x = np.array(e.evaluate([0] * n))
+        y = np.array(e.evaluate([0] * n))
         #self.assertFalse(np.all(x) == np.all(y))
         self.assertTrue(len(set(x) | set(y)) > n // 2)
 
         # But with seeding we expect the same result twice
         np.random.seed(123)
-        x = np.array(e.evaluate([0]*n))
+        x = np.array(e.evaluate([0] * n))
         np.random.seed(123)
-        y = np.array(e.evaluate([0]*n))
+        y = np.array(e.evaluate([0] * n))
         self.assertTrue(np.all(x) == np.all(y))
 
         # Even with many more tasks than workers
         e = pints.ParallelEvaluator(random_int, n_workers=3)
         np.random.seed(123)
-        x = np.array(e.evaluate([0]*100))
+        x = np.array(e.evaluate([0] * 100))
         np.random.seed(123)
-        y = np.array(e.evaluate([0]*100))
+        y = np.array(e.evaluate([0] * 100))
 
     def test_worker(self):
         # Manual test of worker, since cover doesn't pick up on its run method.

--- a/pints/tests/test_evaluators.py
+++ b/pints/tests/test_evaluators.py
@@ -11,7 +11,6 @@ import pints
 import unittest
 
 
-
 class TestEvaluators(unittest.TestCase):
     """
     Tests the evaluator classes and methods.


### PR DESCRIPTION
See #1358

Tasks are evaluated by "workers". Each worker starts with a copy of the main process's random generator. So unless we do some seeding they will all use the same random numbers!

Works like this:

```
main process wants to evaluate f(x) on 100 points x
generates a list of 100 tuples (index, seed, x)

each worker waits for a task, and when it gets one it:
- seeds its private random generator using "seed"
- evaluates f(x)
- passes back a tuple (index, f(x))

main process receives all the (index, f(x)) pairs, 
stores them at results[index] = f(x)
```

By seeding in this way it doesn't matter which worker evaluates f(x), or in which order the tasks are evaluated - the results are always reproducible

(And of course if we don't seed the main process, then they are reproducible but pseudo-random)
