### PR TITLE
Standardise histogram bins across chains

### DIFF
--- a/pints/plot/_histogram.py
+++ b/pints/plot/_histogram.py
@@ -88,33 +88,38 @@ def histogram(
         squeeze=False,    # Tell matlab to always return a 2d axes object
     )
 
+    # Find ranges across all samples
+    stacked_chains = np.vstack(samples)
+    if n_percentiles is None:
+        xmin = np.min(stacked_chains, axis=0)
+        xmax = np.max(stacked_chains, axis=0)
+    else:
+        xmin = np.percentile(stacked_chains,
+                             50 - n_percentiles / 2.,
+                             axis=0)
+        xmax = np.percentile(stacked_chains,
+                             50 + n_percentiles / 2.,
+                             axis=0)
+    xbins = np.linspace(xmin, xmax, bins)
+
     # Plot first samples
     for i in range(n_param):
         for j_list, samples_j in enumerate(samples):
             # Add histogram subplot
             axes[i, 0].set_xlabel(parameter_names[i])
             axes[i, 0].set_ylabel('Frequency')
-            if n_percentiles is None:
-                xmin = np.min(samples_j[:, i])
-                xmax = np.max(samples_j[:, i])
-            else:
-                xmin = np.percentile(samples_j[:, i],
-                                     50 - n_percentiles / 2.)
-                xmax = np.percentile(samples_j[:, i],
-                                     50 + n_percentiles / 2.)
-            xbins = np.linspace(xmin, xmax, bins)
             if use_old_matplotlib:  # pragma: no cover
                 axes[i, 0].hist(
-                    samples_j[:, i], bins=xbins, alpha=alpha, normed=True,
-                    label='Samples ' + str(1 + j_list))
+                    samples_j[:, i], bins=xbins[:, i], alpha=alpha,
+                    normed=True, label='Samples ' + str(1 + j_list))
             else:
                 axes[i, 0].hist(
-                    samples_j[:, i], bins=xbins, alpha=alpha, density=True,
-                    label='Samples ' + str(1 + j_list))
+                    samples_j[:, i], bins=xbins[:, i], alpha=alpha,
+                    density=True, label='Samples ' + str(1 + j_list))
 
             # Add kde plot
             if kde:
-                x = np.linspace(xmin, xmax, 100)
+                x = np.linspace(xmin[i], xmax[i], 100)
                 axes[i, 0].plot(x, stats.gaussian_kde(samples_j[:, i])(x))
 
         # Add reference parameters if given
@@ -130,4 +135,3 @@ def histogram(
 
     plt.tight_layout()
     return fig, axes[:, 0]
-

--- a/pints/plot/_trace.py
+++ b/pints/plot/_trace.py
@@ -107,8 +107,8 @@ def trace(
             axes[i, 1].plot(samples_j[:, i], alpha=alpha)
 
             # Set ylim
-            ymin_all = ymin_all if ymin_all < xmin[i] else xmin[i]
-            ymax_all = ymax_all if ymax_all > xmax[i] else xmax[i]
+            ymin_all = min(ymin_all, xmin[i])
+            ymax_all = max(ymax_all, xmax[i])
         axes[i, 1].set_ylim([ymin_all, ymax_all])
 
         # Add reference parameters if given

--- a/pints/plot/_trace.py
+++ b/pints/plot/_trace.py
@@ -79,15 +79,16 @@ def trace(
 
     # Find ranges across all samples
     stacked_chains = np.vstack(samples)
-    for i in range(n_param):
-        if n_percentiles is None:
-            xmin = np.min(samples_j[:, i])
-            xmax = np.max(samples_j[:, i])
-        else:
-            xmin = np.percentile(samples_j[:, i],
-                                 50 - n_percentiles / 2.)
-            xmax = np.percentile(samples_j[:, i],
-                                 50 + n_percentiles / 2.)
+    if n_percentiles is None:
+        xmin = np.min(stacked_chains, axis=0)
+        xmax = np.max(stacked_chains, axis=0)
+    else:
+        xmin = np.percentile(stacked_chains,
+                             50 - n_percentiles / 2.,
+                             axis=0)
+        xmax = np.percentile(stacked_chains,
+                             50 + n_percentiles / 2.,
+                             axis=0)
     xbins = np.linspace(xmin, xmax, bins)
 
     # Plot first samples
@@ -97,7 +98,7 @@ def trace(
             # Add histogram subplot
             axes[i, 0].set_xlabel(parameter_names[i])
             axes[i, 0].set_ylabel('Frequency')
-            axes[i, 0].hist(samples_j[:, i], bins=xbins, alpha=alpha,
+            axes[i, 0].hist(samples_j[:, i], bins=xbins[:, i], alpha=alpha,
                             label='Samples ' + str(1 + j_list))
 
             # Add trace subplot
@@ -106,8 +107,8 @@ def trace(
             axes[i, 1].plot(samples_j[:, i], alpha=alpha)
 
             # Set ylim
-            ymin_all = ymin_all if ymin_all < xmin else xmin
-            ymax_all = ymax_all if ymax_all > xmax else xmax
+            ymin_all = ymin_all if ymin_all < xmin[i] else xmin[i]
+            ymax_all = ymax_all if ymax_all > xmax[i] else xmax[i]
         axes[i, 1].set_ylim([ymin_all, ymax_all])
 
         # Add reference parameters if given

--- a/pints/plot/_trace.py
+++ b/pints/plot/_trace.py
@@ -77,6 +77,19 @@ def trace(
         squeeze=False,
     )
 
+    # Find ranges across all samples
+    stacked_chains = np.vstack(samples)
+    for i in range(n_param):
+        if n_percentiles is None:
+            xmin = np.min(samples_j[:, i])
+            xmax = np.max(samples_j[:, i])
+        else:
+            xmin = np.percentile(samples_j[:, i],
+                                 50 - n_percentiles / 2.)
+            xmax = np.percentile(samples_j[:, i],
+                                 50 + n_percentiles / 2.)
+    xbins = np.linspace(xmin, xmax, bins)
+
     # Plot first samples
     for i in range(n_param):
         ymin_all, ymax_all = np.inf, -np.inf
@@ -84,15 +97,6 @@ def trace(
             # Add histogram subplot
             axes[i, 0].set_xlabel(parameter_names[i])
             axes[i, 0].set_ylabel('Frequency')
-            if n_percentiles is None:
-                xmin = np.min(samples_j[:, i])
-                xmax = np.max(samples_j[:, i])
-            else:
-                xmin = np.percentile(samples_j[:, i],
-                                     50 - n_percentiles / 2.)
-                xmax = np.percentile(samples_j[:, i],
-                                     50 + n_percentiles / 2.)
-            xbins = np.linspace(xmin, xmax, bins)
             axes[i, 0].hist(samples_j[:, i], bins=xbins, alpha=alpha,
                             label='Samples ' + str(1 + j_list))
 
@@ -126,4 +130,3 @@ def trace(
 
     plt.tight_layout()
     return fig, axes
-


### PR DESCRIPTION
When chains run across different areas, since they use separate bin sizes across the chains, the resultant histograms can be incomparable. This PR picks a consistent bin size across them.

addresses #1389 