### PR TITLE
Stop using triangle wave transform in optimisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
-- [#1420](https://github.com/pints-team/pints/pull/1420) The `Optimisation` objects now distinguish between a best-visited point (`x_best`, with score `f_best`) and a best-guessed point (`x_guessed`, with approximate score `f_guessed`). For most optimisers, the two values are equivalent. As before, the `OptimisationController` now tracks `x_best` and `f_best` by default, but this can be modified using the methods `set_f_guessed_tracking` and `f_guessed_tracking`.
-- 
+- [#1420](https://github.com/pints-team/pints/pull/1420) The `Optimiser` class now distinguishes between a best-visited point (`x_best`, with score `f_best`) and a best-guessed point (`x_guessed`, with approximate score `f_guessed`). For most optimisers, the two values are equivalent. The `OptimisationController` still tracks `x_best` and `f_best` by default, but this can be modified using the methods `set_f_guessed_tracking` and `f_guessed_tracking`.
+
 ### Changed
+- [#1424](https://github.com/pints-team/pints/pull/1424) Fixed a bug in PSO that caused it to use more particles than advertised.
+- [#1424](https://github.com/pints-team/pints/pull/1424) xNES, SNES, PSO, and BareCMAES no longer use a `TriangleWaveTransform` to handle rectangular boundaries (this was found to lead to optimisers diverging in some cases).
+
 ### Deprecated
+
 ### Removed
+- [#1424](https://github.com/pints-team/pints/pull/1424) Removed the `TriangleWaveTransform` class previously used in some optimisers.
+
 ### Fixed
+
 
 ## [0.4.0] - 2021-12-07
 

--- a/docs/source/optimisers/boundary_transformations.rst
+++ b/docs/source/optimisers/boundary_transformations.rst
@@ -1,8 +1,0 @@
-************************
-Boundary transformations
-************************
-
-.. currentmodule:: pints
-
-.. autoclass:: TriangleWaveTransform
-

--- a/docs/source/optimisers/index.rst
+++ b/docs/source/optimisers/index.rst
@@ -16,7 +16,6 @@ or the :class:`OptimisationController` class.
     running
     base_classes
     convenience_methods
-    boundary_transformations
     cmaes_bare
     cmaes
     gradient_descent

--- a/pints/__init__.py
+++ b/pints/__init__.py
@@ -170,7 +170,6 @@ from ._optimisers import (
     optimise,
     Optimiser,
     PopulationBasedOptimiser,
-    TriangleWaveTransform,
 )
 from ._optimisers._cmaes import CMAES
 from ._optimisers._cmaes_bare import BareCMAES

--- a/pints/_optimisers/__init__.py
+++ b/pints/_optimisers/__init__.py
@@ -973,43 +973,6 @@ def optimise(
         function, x0, sigma0, boundaries, transformation, method).run()
 
 
-class TriangleWaveTransform(object):
-    """
-    Transforms from unbounded to (rectangular) bounded parameter space using a
-    periodic triangle-wave transform.
-
-    Note: The transform is applied _inside_ optimisation methods, there is no
-    need to wrap this around your own problem or score function.
-
-    This can be applied as a transformation on ``x`` to implement _rectangular_
-    boundaries in methods with no natural boundary mechanism. It effectively
-    mirrors the search space at every boundary, leading to a continuous (but
-    non-smooth) periodic landscape. While this effectively creates an infinite
-    number of minima/maxima, each one maps to the same point in parameter
-    space.
-
-    It should work well for methods that maintain a single search position or a
-    single search distribution (e.g. :class:`CMAES`, :class:`xNES`,
-    :class:`SNES`), which will end up in one of the many mirror images.
-    However, for methods that use independent search particles (e.g.
-    :class:`PSO`) it could lead to a scattered population, with different
-    particles exploring different mirror images. Other strategies should be
-    used for such problems.
-    """
-
-    def __init__(self, boundaries):
-        self._lower = boundaries.lower()
-        self._upper = boundaries.upper()
-        self._range = self._upper - self._lower
-        self._range2 = 2 * self._range
-
-    def __call__(self, x):
-        y = np.remainder(x - self._lower, self._range2)
-        z = np.remainder(y, self._range)
-        return ((self._lower + z) * (y < self._range)
-                + (self._upper - z) * (y >= self._range))
-
-
 def curve_fit(f, x, y, p0, boundaries=None, threshold=None, max_iter=None,
               max_unchanged=200, verbose=False, parallel=False, method=None):
     """

--- a/pints/_optimisers/_pso.py
+++ b/pints/_optimisers/_pso.py
@@ -113,19 +113,22 @@ class PSO(pints.PopulationBasedOptimiser):
 
         # Set initial positions
         self._xs.append(np.array(self._x0, copy=True))
+
+        # Attempt to sample n - 1 points from the boundaries
         if self._boundaries is not None:
-            # Attempt to sample n - 1 points from the boundaries
             try:
                 self._xs.extend(
                     self._boundaries.sample(self._population_size - 1))
             except NotImplementedError:
-                # Not all boundaries implement sampling
+                # Not all boundaries implement sampling.
                 pass
+
         # If we couldn't sample from the boundaries, use gaussian sampling
         # around x0.
-        for i in range(1, self._population_size):
-            self._xs.append(np.random.normal(self._x0, self._sigma0))
-        self._xs = np.array(self._xs, copy=True)
+        if len(self._xs) < self._population_size:
+            for i in range(self._population_size - 1):
+                self._xs.append(np.random.normal(self._x0, self._sigma0))
+        self._xs = np.array(self._xs)
 
         # Set initial velocities
         for i in range(self._population_size):
@@ -141,29 +144,15 @@ class PSO(pints.PopulationBasedOptimiser):
         self._fg = float('inf')
         self._pg = self._xs[0]
 
-        # Create boundary transform, or use manual boundary checking
-        self._manual_boundaries = False
-        self._boundary_transform = None
-        if isinstance(self._boundaries, pints.RectangularBoundaries):
-            self._boundary_transform = pints.TriangleWaveTransform(
-                self._boundaries)
-        elif self._boundaries is not None:
-            self._manual_boundaries = True
-
-        # Create safe xs to pass to user
-        if self._boundary_transform is not None:
-            # Rectangular boundaries? Then apply transform to xs
-            self._xs = self._boundary_transform(self._xs)
-        if self._manual_boundaries:
-            # Manual boundaries? Then filter out out-of-bounds points from xs
+        # Boundaries? Then filter out out-of-bounds points from xs
+        self._user_xs = self._xs
+        if self._boundaries is not None:
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
             if len(self._user_xs) == 0:     # pragma: no cover
                 warnings.warn(
                     'All initial PSO particles are outside the boundaries.')
-        else:
-            self._user_xs = self._xs
 
         # Set local/global exploration balance
         self.set_local_global_balance()
@@ -194,8 +183,8 @@ class PSO(pints.PopulationBasedOptimiser):
     def set_local_global_balance(self, r=0.5):
         """
         Set the balance between local and global exploration for each particle,
-        using a parameter `r` such that `r = 1` is a fully local search and
-        `r = 0` is a fully global search.
+        using a parameter ``r`` such that ``r = 1`` is a fully local search and
+        ``r = 0`` is a fully global search.
         """
         if self._running:
             raise Exception('Cannot change settings during run.')
@@ -234,8 +223,8 @@ class PSO(pints.PopulationBasedOptimiser):
             raise Exception('ask() not called before tell()')
         self._ready_for_tell = False
 
-        # Manual boundaries? Then reconstruct full fx vector
-        if self._manual_boundaries and len(fx) < self._population_size:
+        # Boundaries? Then reconstruct full fx vector
+        if self._boundaries is not None and len(fx) < self._population_size:
             user_fx = fx
             fx = np.ones((self._population_size, )) * float('inf')
             fx[self._user_ids] = user_fx
@@ -265,19 +254,14 @@ class PSO(pints.PopulationBasedOptimiser):
             # Update position
             self._xs[i] += self._vs[i]
 
-        # Create safe xs to pass to user
-        if self._boundary_transform is not None:
-            # Rectangular boundaries? Then apply transform to xs
-            self._user_xs = self._xs = self._boundary_transform(self._xs)
-        elif self._manual_boundaries:
-            # Manual boundaries? Then filter out out-of-bounds points from xs
+        # Boundaries? Then filter out out-of-bounds points from xs
+        self._user_xs = self._xs
+        if self._boundaries is not None:
             self._user_ids = np.nonzero(
                 [self._boundaries.check(x) for x in self._xs])
             self._user_xs = self._xs[self._user_ids]
             if len(self._user_xs) == 0:     # pragma: no cover
                 warnings.warn('All PSO particles are outside the boundaries.')
-        else:
-            self._user_xs = self._xs
 
         # Update global best score
         i = np.argmin(self._fl)

--- a/pints/tests/test_opt_optimisation_controller.py
+++ b/pints/tests/test_opt_optimisation_controller.py
@@ -233,19 +233,19 @@ class TestOptimisationController(unittest.TestCase):
         self.assertEqual(lines[4],
                          'Iter. Eval. Best      Current   Time m:s')
         self.assertEqual(lines[5][:-3],
-                         '0     6     -4.140462 -4.140462   0:0')
+                         '0     3     -4.140462 -4.140462   0:0')
         self.assertEqual(lines[6][:-3],
-                         '1     12    -4.140462 -4.140473   0:0')
+                         '1     6     -4.140462 -4.140465   0:0')
         self.assertEqual(lines[7][:-3],
-                         '2     18    -4.140462 -4.140462   0:0')
+                         '2     11    -4.140462 -4.140462   0:0')
         self.assertEqual(lines[8][:-3],
-                         '3     24    -4.140462 -4.140466   0:0')
+                         '3     16    -4.140462 -4.140466   0:0')
         self.assertEqual(lines[9][:-3],
-                         '6     42    -4.140462 -4.140462   0:0')
+                         '6     33    -4.140462 -4.140462   0:0')
         self.assertEqual(lines[10][:-3],
-                         '9     60    -4.140462 -4.140462   0:0')
+                         '9     51    -4.140462 -4.140462   0:0')
         self.assertEqual(lines[11][:-3],
-                         '10    60    -4.140462 -4.140462   0:0')
+                         '10    51    -4.140462 -4.140462   0:0')
         self.assertEqual(
             lines[12], 'Halting: Maximum number of iterations (10) reached.')
 

--- a/pints/tests/test_opt_optimisation_controller.py
+++ b/pints/tests/test_opt_optimisation_controller.py
@@ -415,8 +415,6 @@ class TestOptimisationController(unittest.TestCase):
         opt.set_log_to_screen(False)
         opt.set_max_unchanged_iterations(50, 1e-11)
 
-        np.random.seed(123)
-
         # Before run methods return None
         self.assertIsNone(opt.iterations())
         self.assertIsNone(opt.evaluations())
@@ -426,8 +424,8 @@ class TestOptimisationController(unittest.TestCase):
         opt.run()
         t_upper = t.time()
 
-        self.assertEqual(opt.iterations(), 75)
-        self.assertEqual(opt.evaluations(), 450)
+        self.assertEqual(opt.iterations(), 84)
+        self.assertEqual(opt.evaluations(), 495)
 
         # Time after run is greater than zero
         self.assertIsInstance(opt.time(), float)
@@ -446,9 +444,8 @@ class TestOptimisationController(unittest.TestCase):
         opt.set_max_unchanged_iterations(None)
         opt.set_max_iterations(10)
         opt.run()
-        with self.assertRaisesRegex(RuntimeError,
-                                    "Controller is valid for single use only"):
-            opt.run()
+        self.assertRaisesRegex(
+            RuntimeError, 'Controller is valid for single use only', opt.run)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
See #25 (and #1420)

It leads to errors with xnes, where it just keeps increasing sigma because it keeps finding points in the next "period" of the search space. The `TriangleWaveTransform` is used by PSO, xNES, SNES, and BareCMAES. All of these methods can easily deal with "inf" for any evaluation, and this was already the way we handled arbitrary shaped boundaries.

In addition, found and fixed a bug in PSO where we (I) initialised with too many particles