### PR TITLE
Test on Python 3.10

### DIFF
--- a/.github/workflows/copyright-test.yml
+++ b/.github/workflows/copyright-test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
 
       - name: install pints
         run: |

--- a/.github/workflows/copyright-test.yml
+++ b/.github/workflows/copyright-test.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: python-latest
           architecture: x64
 
       - name: install pints

--- a/.github/workflows/copyright-test.yml
+++ b/.github/workflows/copyright-test.yml
@@ -24,9 +24,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v1
-        with:
-          python-version: python-latest
-          architecture: x64
 
       - name: install pints
         run: |

--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
 
       - name: install pints
         run: |

--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: python-latest
           architecture: x64
 
       - name: install pints

--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -24,9 +24,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v1
-        with:
-          python-version: python-latest
-          architecture: x64
 
       - name: install pints
         run: |

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
 
       - name: install pints
         run: |

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: python-latest
           architecture: x64
 
       - name: install pints

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -24,9 +24,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v1
-        with:
-          python-version: python-latest
-          architecture: x64
 
       - name: install pints
         run: |

--- a/.github/workflows/notebook-interfaces-test.yml
+++ b/.github/workflows/notebook-interfaces-test.yml
@@ -16,9 +16,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v1
-        with:
-          python-version: python-latest
-          architecture: x64
 
       # We use e.g. install pints[stan] to install dependencies for interfaces
       # that have some code in pints/interfaces. Dependencies that are not used

--- a/.github/workflows/notebook-interfaces-test.yml
+++ b/.github/workflows/notebook-interfaces-test.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: python-latest
           architecture: x64
 
       # We use e.g. install pints[stan] to install dependencies for interfaces

--- a/.github/workflows/notebook-interfaces-test.yml
+++ b/.github/workflows/notebook-interfaces-test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
 
       # We use e.g. install pints[stan] to install dependencies for interfaces
       # that have some code in pints/interfaces. Dependencies that are not used

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
 
       - name: install pints
         run: |

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -16,9 +16,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v1
-        with:
-          python-version: python-latest
-          architecture: x64
 
       - name: install pints
         run: |

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: python-latest
           architecture: x64
 
       - name: install pints

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
 
       - name: install pints
         run: |

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: python-latest
           architecture: x64
 
       - name: install pints

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -24,9 +24,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v1
-        with:
-          python-version: python-latest
-          architecture: x64
 
       - name: install pints
         run: |

--- a/.github/workflows/unit-test-os-coverage.yml
+++ b/.github/workflows/unit-test-os-coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
 
       - name: install pints
         run: |

--- a/.github/workflows/unit-test-os-coverage.yml
+++ b/.github/workflows/unit-test-os-coverage.yml
@@ -28,9 +28,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v1
-        with:
-          python-version: python-latest
-          architecture: x64
 
       - name: install pints
         run: |

--- a/.github/workflows/unit-test-os-coverage.yml
+++ b/.github/workflows/unit-test-os-coverage.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: python-latest
           architecture: x64
 
       - name: install pints

--- a/.github/workflows/unit-test-python-coverage.yml
+++ b/.github/workflows/unit-test-python-coverage.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/unit-test-python-coverage.yml
+++ b/.github/workflows/unit-test-python-coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -16,9 +16,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v1
-        with:
-          python-version: python-latest
-          architecture: x64
 
       - name: install dependencies
         run: |

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: python-latest
           architecture: x64
 
       - name: install dependencies

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
 
       - name: install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ All notable changes to this project will be documented in this file.
 - [#1417](https://github.com/pints-team/pints/pull/1417) Added a module `toy.stochastic` for stochastic models. In particular, `toy.stochastic.MarkovJumpModel` implements Gillespie's algorithm for easier future implementation of stochastic models.
 
 ### Changed
+- [#1439](https://github.com/pints-team/pints/pull/1439), [#1433](https://github.com/pints-team/pints/pull/1433) PINTS is no longer tested on Python 3.5. Testing for Python 3.10 has been added.
 - [#1435](https://github.com/pints-team/pints/pull/1435) The optional Stan interface now uses (and requires) pystan 3 or newer. The ``update_data`` method has been remove (model compilation is now cached so that there is no performance benefit to using this method).
-- [#1433](https://github.com/pints-team/pints/pull/1433) PINTS is no longer tested on Python 3.5.
 - [#1424](https://github.com/pints-team/pints/pull/1424) Fixed a bug in PSO that caused it to use more particles than advertised.
 - [#1424](https://github.com/pints-team/pints/pull/1424) xNES, SNES, PSO, and BareCMAES no longer use a `TriangleWaveTransform` to handle rectangular boundaries (this was found to lead to optimisers diverging in some cases).
 


### PR DESCRIPTION
- [x] Now testing on Python 3.10
- [x] Updated rest of 3.9 tests to just use whatever the latest supported version is

@fcooper8472 @martinjrobins what do you think of the 2nd change? Is this a good idea in your opinion (the whole `with` block can be removed in that case, x64 is default too), or are we better off explicitly specifying the newest version we want to test on?