### PR TITLE
Parallelisation fix for ABC Rejection

### DIFF
--- a/pints/_abc/_abc_rejection.py
+++ b/pints/_abc/_abc_rejection.py
@@ -70,7 +70,7 @@ class RejectionABC(pints.ABCSampler):
         if np.sum(accepted) == 0:
             return None
         else:
-            return [self._xs.tolist() for c, x in
+            return [x.tolist() for c, x in
                     enumerate(accepted) if x.all()]
 
     def threshold(self):


### PR DESCRIPTION
ABC Rejection is not working properly when parallelisation is enabled. In particular, if we have 8 cores for example, we try 8 sample values at once. The algorithm accepts all of them if at least one of them is below the error threshold. This is incorrect, only the ones below the error threshold should be accepted.