### PR TITLE
Adds a ComposedBoundaries, similar to ComposedLogPrior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- [#1527](https://github.com/pints-team/pints/pull/1527) Added a `ComposedBoundaries` class that lets you compose multiple `Boundaries` classes into a higher dimensional one.
 - [#1500](https://github.com/pints-team/pints/pull/1500) Added a `CensoredGaussianLogLikelihood` class that calculates the censored Gaussian log-likelihood.
 - [#1505](https://github.com/pints-team/pints/pull/1505) Added notes to `ErrorMeasure` and `LogPDF` to say parameters must be real and continuous.
 - [#1499](https://github.com/pints-team/pints/pull/1499) Added a log-uniform prior class.

--- a/docs/source/boundaries.rst
+++ b/docs/source/boundaries.rst
@@ -12,11 +12,14 @@ implementation of the :class:`Boundaries` interface.
 Overview:
 
 - :class:`Boundaries`
+- :class:`ComposedBoundaries`
 - :class:`LogPDFBoundaries`
 - :class:`RectangularBoundaries`
 
 
 .. autoclass:: Boundaries
+
+.. autoclass:: ComposedBoundaries
 
 .. autoclass:: LogPDFBoundaries
 

--- a/pints/__init__.py
+++ b/pints/__init__.py
@@ -134,6 +134,7 @@ from ._log_likelihoods import (
 #
 from ._boundaries import (
     Boundaries,
+    ComposedBoundaries,
     LogPDFBoundaries,
     RectangularBoundaries,
 )

--- a/pints/tests/shared.py
+++ b/pints/tests/shared.py
@@ -395,3 +395,26 @@ class SwappingTransformation(pints.Transformation):
 
     def to_search(self, p):
         return p[::-1]
+
+
+class UnitCircleBoundaries2D(pints.Boundaries):
+    """
+    A 2d set of circular boundaries (similar but different to the hypersphere
+    boundaries above...) with radius 1.
+    """
+    def __init__(self, mx=0, my=0):
+        self._c = np.array([mx, my])
+
+    def n_parameters(self):
+        return 2
+
+    def check(self, parameters):
+        x, y = parameters  # Let Python do exception
+        return np.sum((parameters - self._c)**2) < 1
+
+    def sample(self, n=1):
+        r = np.sqrt(np.random.uniform(0, 1, size=(n,)))
+        t = np.random.uniform(0, np.pi, size=(n, ))
+        return np.array([self._c[0] + r * np.cos(t),
+                         self._c[1] + r * np.sin(t)]).T
+

--- a/pints/tests/test_test_shared.py
+++ b/pints/tests/test_test_shared.py
@@ -10,7 +10,9 @@ import os
 import sys
 import unittest
 
-from shared import StreamCapture, TemporaryDirectory
+import numpy as np
+
+from shared import StreamCapture, TemporaryDirectory, UnitCircleBoundaries2D
 
 
 class TestSharedTestModule(unittest.TestCase):
@@ -73,6 +75,42 @@ class TestSharedTestModule(unittest.TestCase):
 
         # Test runtime error when used outside of context
         self.assertRaises(RuntimeError, d.path, 'hello.txt')
+
+    def test_unit_circle_boundaries_2d(self):
+        # Tests the 2d unit circle boundaries used in composed boundaries
+        # testing.
+        c = UnitCircleBoundaries2D()
+        self.assertEqual(c.n_parameters(), 2)
+        self.assertTrue(c.check([0, 0]))
+        self.assertTrue(c.check([0.5, 0]))
+        self.assertTrue(c.check([-0.5, 0]))
+        self.assertTrue(c.check([0, 0.5]))
+        self.assertTrue(c.check([0, -0.5]))
+        self.assertFalse(c.check([1, 0]))
+        self.assertFalse(c.check([-1, 0]))
+        self.assertFalse(c.check([0, 1]))
+        self.assertFalse(c.check([0, -1]))
+        self.assertTrue(c.check([1 - 1e-12, 0]))
+        self.assertTrue(c.check([-1 + 1e-12, 0]))
+        self.assertTrue(c.check([0, 1 - 1e-12]))
+        self.assertTrue(c.check([0, -1 + 1e-12]))
+        x, y = np.cos(0.123), np.sin(0.123)
+        self.assertFalse(c.check([x, y]))
+        xs = c.sample(100)
+        self.assertEqual(xs.shape, (100, 2))
+        for i, x in enumerate(xs):
+            self.assertTrue(c.check(x))
+
+        c = UnitCircleBoundaries2D(-5, 2)
+        self.assertEqual(c.n_parameters(), 2)
+        self.assertFalse(c.check([0, 0]))
+        self.assertTrue(c.check([-5, 2]))
+        self.assertTrue(c.check([-5, 3 - 1e-12]))
+        for i, x in enumerate(c.sample(10)):
+            self.assertTrue(c.check(x))
+
+        self.assertRaises(Exception, c.check, [0, 0, 0])
+        self.assertRaises(Exception, c.check, [0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Lets you create a boundaries object from other boundaries objects.

The naming and syntax is the same as ComposedLogPrior and ComposedTransformation

This has a use case in our ion channel issues, where we often have 2d boundaries on a pair of parameters, and then a total set of boundaries made up of multiples of these 2d ones