### PR TITLE
Updated github actions versions.

### DIFF
--- a/.github/workflows/copyright-test.yml
+++ b/.github/workflows/copyright-test.yml
@@ -20,10 +20,10 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
             python-version: '3.11'
 

--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -20,10 +20,10 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -20,10 +20,10 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/notebook-interfaces-test.yml
+++ b/.github/workflows/notebook-interfaces-test.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -20,10 +20,13 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
 
       - name: install pints
         run: |

--- a/.github/workflows/unit-test-os-coverage.yml
+++ b/.github/workflows/unit-test-os-coverage.yml
@@ -25,10 +25,10 @@ jobs:
         # Note: Ubuntu 22 is checked by other tests
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/unit-test-python-coverage.yml
+++ b/.github/workflows/unit-test-python-coverage.yml
@@ -25,10 +25,10 @@ jobs:
         # Note: Latest version is tested by coverage test and os tests
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
Updates `checkout` to v4 and `setup-python` to v5 to fix this warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

And sets a python version in the style test to fix this warning:

> The `python-version` input is not set. The version of Python currently in `PATH` will be used.