### PR TITLE
Updates for numpy 2 compatibility

### DIFF
--- a/pints/_optimisers/_nelder_mead.py
+++ b/pints/_optimisers/_nelder_mead.py
@@ -186,7 +186,7 @@ class NelderMead(pints.Optimiser):
                     self._xs[1 + i][i] *= x_grow
 
             # Ask for initial points
-            return np.array(self._xs, copy=True)
+            return np.copy(self._xs)
 
         # Shrink operation
         if self._shrink:
@@ -194,7 +194,7 @@ class NelderMead(pints.Optimiser):
                 self._xs[1 + i] = \
                     self._xs[0] + self._ys * (self._xs[1 + i] - self._xs[0])
 
-            return np.array(self._xs[1:], copy=True)
+            return np.copy(self._xs[1:])
 
         # Start of normal iteration, ask for reflection point
         if self._xr is None:
@@ -240,7 +240,7 @@ class NelderMead(pints.Optimiser):
 
         # Initialise
         if self._fs is None:
-            fx = np.array(fx, copy=True)
+            fx = np.copy(fx)
             if np.prod(fx.shape) != self._n_parameters + 1:
                 raise ValueError(
                     'Expecting a vector of length (1 + n_parameters).')
@@ -251,7 +251,7 @@ class NelderMead(pints.Optimiser):
 
         # Shrink
         if self._shrink:
-            fx = np.array(fx, copy=False)
+            fx = np.asarray(fx)
             if np.prod(fx.shape) != self._n_parameters:
                 raise ValueError(
                     'Expecting a vector of length n_parameters.')

--- a/pints/tests/test_mcmc_relativistic.py
+++ b/pints/tests/test_mcmc_relativistic.py
@@ -8,7 +8,7 @@
 #
 import unittest
 import numpy as np
-from scipy.integrate import cumtrapz, quad
+from scipy.integrate import cumulative_trapezoid, quad
 from scipy.interpolate import interp1d
 import pints
 import pints.toy
@@ -238,7 +238,8 @@ class TestRelativisticMCMC(unittest.TestCase):
         # in this test, the values of m and c are nice enough that this
         # function can be used for the comparison, and we check that the
         # results are the same.
-        cdf = cumtrapz(1 / c * pdf(integration_grid), x=integration_grid)
+        cdf = cumulative_trapezoid(
+            1 / c * pdf(integration_grid), x=integration_grid)
 
         # Interpolate to get approximate inverse
         inv_cdf = interp1d([0.0] + list(cdf), integration_grid)

--- a/pints/tests/test_mcmc_relativistic.py
+++ b/pints/tests/test_mcmc_relativistic.py
@@ -8,12 +8,18 @@
 #
 import unittest
 import numpy as np
-from scipy.integrate import cumulative_trapezoid, quad
+from scipy.integrate import quad
 from scipy.interpolate import interp1d
 import pints
 import pints.toy
 
 from shared import StreamCapture
+
+# For compatibility with scipy<1.12, released 2024-01-20
+try:
+    from scipy.integrate import cumulative_trapezoid
+except ImportError:     # pragma: no cover
+    from scipy.integrate import cumtrapz as cumulative_trapezoid
 
 
 class TestRelativisticMCMC(unittest.TestCase):


### PR DESCRIPTION
1. Not many changes in PINTS luckily, just replacing a `np.array(x, copy=False)` with `np.asarray(x)`
2. Remaining errors are in `pycma`. These are already fixed in development but we'll need to wait for a new release.