### PR TITLE
Notebook tests fixes

### DIFF
--- a/.github/workflows/notebook-interfaces-test.yml
+++ b/.github/workflows/notebook-interfaces-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
 
       # We use e.g. install pints[stan] to install dependencies for interfaces
       # that have some code in pints/interfaces. Dependencies that are not used

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -26,6 +26,11 @@ jobs:
           python -m pip install .
           python -m pip install .[dev]
 
+      # Install pandas for "estimation renewal" notebook
+      - name: install pandas
+        run: |
+          python -m pip install pandas
+
       - name: run jupyter notebooks
         run: |
           python run-tests.py --books


### PR DESCRIPTION
- Interfaces notebooks require older python because stan doesn't support 3.13 yet
- Renewal-estimation notebook uses pandas, wasn't easy to replace so added pandas installation to notebook testing